### PR TITLE
Add Pokémon TCG collector web app

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Pokémon TCG Sammler</title>
+  <title>Pokefolio – Pokémon TCG Sammlung</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
@@ -13,121 +13,569 @@
 </head>
 <body>
   <header class="app-header">
-    <div class="header-content">
-      <h1>Pokémon TCG Sammler</h1>
-      <p>Durchsuche jede Karte, entdecke neue Sets und verwalte deine Sammlung mit Hilfe einer starken Pokémon TCG API.</p>
+    <div class="branding">
+      <h1>Pokefolio</h1>
+      <p>Die Komplettlösung für deine Pokémon TCG Sammlung, Preise, Wunschlisten und Decks.</p>
     </div>
-    <div class="api-key">
-      <label for="apiKeyInput">API-Schlüssel (optional)</label>
-      <div class="api-key-controls">
-        <input type="text" id="apiKeyInput" placeholder="X-Api-Key hier einfügen">
-        <button id="saveApiKeyButton" class="primary-button">Speichern</button>
-        <button id="clearApiKeyButton" class="secondary">Entfernen</button>
+    <div class="header-actions">
+      <div class="api-key">
+        <label for="apiKeyInput">Pokémon TCG API-Schlüssel</label>
+        <div class="api-key-controls">
+          <input type="text" id="apiKeyInput" placeholder="Optionaler API-Schlüssel für höhere Limits">
+          <button id="saveApiKeyButton" class="primary-button" type="button">Speichern</button>
+          <button id="clearApiKeyButton" class="secondary" type="button">Entfernen</button>
+        </div>
+        <small>Ohne Schlüssel gelten die öffentlichen Limits. Ein persönlicher Key erhöht die täglichen Anfragen.</small>
+        <div id="apiKeyFeedback" class="feedback" role="status" aria-live="polite"></div>
       </div>
-      <small>Falls du einen eigenen Schlüssel besitzt, erhöht dies das tägliche Limit.</small>
-      <div id="apiKeyFeedback" class="feedback" role="status" aria-live="polite"></div>
     </div>
+    <nav class="main-nav" aria-label="Hauptnavigation">
+      <button class="nav-button is-active" type="button" data-section="search">Suche &amp; Scanner</button>
+      <button class="nav-button" type="button" data-section="collection">Sammlung</button>
+      <button class="nav-button" type="button" data-section="dashboard">Dashboard</button>
+      <button class="nav-button" type="button" data-section="wishlist">Wunschliste</button>
+      <button class="nav-button" type="button" data-section="deck">Deck-Builder</button>
+      <button class="nav-button" type="button" data-section="export">Export &amp; Backups</button>
+      <button class="nav-button" type="button" data-section="settings">Einstellungen</button>
+    </nav>
   </header>
 
   <main>
-    <section id="searchSection" class="panel">
-      <div class="panel-header">
-        <h2>Kartensuche</h2>
-        <p>Nutze die offizielle Pokémon TCG API, um Karten zu finden und deiner Sammlung hinzuzufügen.</p>
-      </div>
-      <form id="searchForm" class="search-form">
-        <div class="form-group">
-          <label for="searchQuery">Name oder Stichwort</label>
-          <input id="searchQuery" name="query" type="search" placeholder="z. B. Pikachu oder Glurak">
+    <section id="searchSection" class="view is-active" data-section="search">
+      <article class="panel">
+        <div class="panel-header">
+          <h2>Kartensuche</h2>
+          <p>Durchsuche die komplette Datenbank nach Namen, Sets, Typen oder Seltenheiten.</p>
         </div>
-        <div class="form-group">
-          <label for="setFilter">Set</label>
-          <select id="setFilter" name="set">
-            <option value="">Alle Sets</option>
-          </select>
+        <form id="searchForm" class="search-form">
+          <div class="form-row">
+            <label for="searchQuery">Name oder Stichwort</label>
+            <input id="searchQuery" name="query" type="search" placeholder="z. B. Glurak, Pikachu VMAX oder Trainer" autocomplete="off">
+          </div>
+          <div class="filter-grid">
+            <label class="form-row">
+              <span>Set</span>
+              <select id="setFilter" name="set">
+                <option value="">Alle Sets</option>
+              </select>
+            </label>
+            <label class="form-row">
+              <span>Serie</span>
+              <select id="seriesFilter" name="series">
+                <option value="">Alle Serien</option>
+              </select>
+            </label>
+            <label class="form-row">
+              <span>Typ</span>
+              <select id="typeFilter" name="type">
+                <option value="">Alle Typen</option>
+              </select>
+            </label>
+            <label class="form-row">
+              <span>Supertype</span>
+              <select id="supertypeFilter" name="supertype">
+                <option value="">Alle</option>
+              </select>
+            </label>
+            <label class="form-row">
+              <span>Seltenheit</span>
+              <select id="rarityFilter" name="rarity">
+                <option value="">Alle Seltenheiten</option>
+              </select>
+            </label>
+            <label class="form-row">
+              <span>Regulationsmarke</span>
+              <select id="regulationFilter" name="regulation">
+                <option value="">Alle</option>
+              </select>
+            </label>
+            <label class="form-row">
+              <span>Illustrator</span>
+              <input id="artistFilter" name="artist" type="text" placeholder="Name des Illustrators">
+            </label>
+            <label class="form-row">
+              <span>Jahr</span>
+              <input id="yearFilter" name="year" type="number" min="1996" max="2099" step="1" placeholder="z. B. 1999">
+            </label>
+            <label class="form-row">
+              <span>Sortierung</span>
+              <select id="sortOrder" name="sort">
+                <option value="name">Name (A→Z)</option>
+                <option value="-name">Name (Z→A)</option>
+                <option value="set.releaseDate">Release Datum (aufsteigend)</option>
+                <option value="-set.releaseDate">Release Datum (absteigend)</option>
+                <option value="set">Set</option>
+              </select>
+            </label>
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="primary-button">Suchen</button>
+            <button type="reset" class="secondary" id="resetSearchButton">Zurücksetzen</button>
+          </div>
+        </form>
+        <div id="searchFeedback" class="feedback" role="status" aria-live="polite"></div>
+      </article>
+
+      <article class="panel">
+        <div class="panel-header">
+          <h2>Suchergebnisse</h2>
+          <p>Füge Karten zur Sammlung, Wunschliste oder direkt zu einem Deck hinzu.</p>
         </div>
-        <div class="form-group">
-          <label for="typeFilter">Typ</label>
-          <select id="typeFilter" name="type">
-            <option value="">Alle Typen</option>
-          </select>
+        <div id="resultsGrid" class="card-grid" aria-live="polite"></div>
+      </article>
+
+      <article class="panel">
+        <div class="panel-header">
+          <h2>Aktuelle Sets &amp; Releases</h2>
+          <p>Neue, beliebte und zuletzt erschienene Sets im Überblick.</p>
         </div>
-        <div class="form-group">
-          <label for="rarityFilter">Seltenheit</label>
-          <select id="rarityFilter" name="rarity">
-            <option value="">Alle Seltenheiten</option>
-          </select>
+        <div id="setsGrid" class="set-grid" aria-live="polite"></div>
+      </article>
+
+      <article class="panel">
+        <div class="panel-header">
+          <h2>Kartenscanner</h2>
+          <p>Nutze die Kamera für OCR-gestützte Texterkennung. Beste Ergebnisse mit guter Ausleuchtung.</p>
         </div>
-        <button type="submit" class="primary-button">Suchen</button>
-      </form>
-      <div id="searchFeedback" class="feedback" role="status" aria-live="polite"></div>
+        <div class="scanner-controls">
+          <button id="startScannerButton" type="button" class="primary-button">Kamera starten</button>
+          <button id="captureCardButton" type="button" class="secondary" disabled>Karte erkennen</button>
+          <button id="stopScannerButton" type="button" class="secondary" disabled>Stoppen</button>
+        </div>
+        <div class="scanner-view">
+          <video id="scannerVideo" autoplay playsinline muted></video>
+          <canvas id="scannerCanvas" hidden></canvas>
+          <div class="scanner-overlay">Halte die Karte ruhig im Rahmen</div>
+        </div>
+        <div id="scannerFeedback" class="feedback" role="status" aria-live="polite"></div>
+        <div id="scannerResults" class="card-grid"></div>
+      </article>
     </section>
 
-    <section id="setsSection" class="panel">
-      <div class="panel-header">
-        <h2>Aktuelle Sets</h2>
-        <p>Stöbere durch neue und beliebte Sets.</p>
-      </div>
-      <div id="setsGrid" class="set-grid" aria-live="polite"></div>
+    <section id="collectionSection" class="view" data-section="collection" hidden>
+      <article class="panel">
+        <div class="panel-header">
+          <h2>Meine Sammlung</h2>
+          <p>Verwalte Karten, Zustände, Kaufpreise und Werte. Alle Daten bleiben lokal gespeichert.</p>
+        </div>
+        <form id="collectionFilterForm" class="filter-grid">
+          <label class="form-row">
+            <span>Set</span>
+            <select id="collectionSetFilter" name="set">
+              <option value="">Alle</option>
+            </select>
+          </label>
+          <label class="form-row">
+            <span>Serie</span>
+            <select id="collectionSeriesFilter" name="series">
+              <option value="">Alle</option>
+            </select>
+          </label>
+          <label class="form-row">
+            <span>Seltenheit</span>
+            <select id="collectionRarityFilter" name="rarity">
+              <option value="">Alle</option>
+            </select>
+          </label>
+          <label class="form-row">
+            <span>Typ</span>
+            <select id="collectionTypeFilter" name="type">
+              <option value="">Alle</option>
+            </select>
+          </label>
+          <label class="form-row">
+            <span>Zustand</span>
+            <select id="collectionConditionFilter" name="condition">
+              <option value="">Alle</option>
+            </select>
+          </label>
+          <label class="form-row">
+            <span>Sprache</span>
+            <select id="collectionLanguageFilter" name="language">
+              <option value="">Alle</option>
+            </select>
+          </label>
+          <label class="form-row">
+            <span>Sortierung</span>
+            <select id="collectionSort" name="sort">
+              <option value="name">Name</option>
+              <option value="-value">Wert (absteigend)</option>
+              <option value="value">Wert (aufsteigend)</option>
+              <option value="set">Set &amp; Nummer</option>
+              <option value="added">Zuletzt hinzugefügt</option>
+            </select>
+          </label>
+        </form>
+        <div id="collectionSummary" class="summary-grid"></div>
+        <div id="collectionFeedback" class="feedback" role="status" aria-live="polite"></div>
+        <div id="collectionEmptyState" class="empty-state">Noch keine Karten hinzugefügt.</div>
+        <div id="collectionGrid" class="card-grid"></div>
+      </article>
     </section>
 
-    <section id="resultsSection" class="panel">
-      <div class="panel-header">
-        <h2>Suchergebnisse</h2>
-        <p>Füge Karten zu deiner Sammlung hinzu oder sieh dir Details an.</p>
-      </div>
-      <div id="resultsGrid" class="card-grid" aria-live="polite"></div>
+    <section id="dashboardSection" class="view" data-section="dashboard" hidden>
+      <article class="panel">
+        <div class="panel-header">
+          <h2>Sammlungs-Dashboard</h2>
+          <p>Überblick über Gesamtwert, Fortschritt je Set, Zustände und Raritäten.</p>
+        </div>
+        <div id="dashboardOverview" class="summary-grid"></div>
+      </article>
+      <article class="panel">
+        <div class="panel-header">
+          <h3>Set-Fortschritt</h3>
+          <p>Vergleiche deine Sammlung mit der Gesamtgröße der Sets.</p>
+        </div>
+        <div id="setProgressList" class="progress-list"></div>
+      </article>
+      <article class="panel">
+        <div class="panel-header">
+          <h3>Raritäts- und Zustandsverteilung</h3>
+        </div>
+        <div id="rarityDistribution" class="progress-list"></div>
+        <div id="conditionDistribution" class="progress-list"></div>
+      </article>
+      <article class="panel">
+        <div class="panel-header">
+          <h3>Preisalarme &amp; Hinweise</h3>
+        </div>
+        <div id="alertsList" class="alerts-list" aria-live="polite"></div>
+      </article>
     </section>
 
-    <section id="collectionSection" class="panel">
-      <div class="panel-header">
-        <h2>Meine Sammlung</h2>
-        <p>Alles, was du hinzufügst, bleibt lokal auf diesem Gerät gespeichert.</p>
-      </div>
-      <div id="collectionFeedback" class="feedback" role="status" aria-live="polite"></div>
-      <div id="collectionEmptyState" class="empty-state">Noch keine Karten hinzugefügt.</div>
-      <div id="collectionGrid" class="card-grid"></div>
+    <section id="wishlistSection" class="view" data-section="wishlist" hidden>
+      <article class="panel">
+        <div class="panel-header">
+          <h2>Wunschliste</h2>
+          <p>Behalte Karten im Blick, setze Zielpreise und erkenne Deals auf einen Blick.</p>
+        </div>
+        <div id="wishlistFeedback" class="feedback" role="status" aria-live="polite"></div>
+        <div id="wishlistEmptyState" class="empty-state">Noch keine Karten auf der Wunschliste.</div>
+        <div id="wishlistGrid" class="card-grid"></div>
+      </article>
     </section>
 
-    <section id="scannerSection" class="panel">
-      <div class="panel-header">
-        <h2>Kartenscan</h2>
-        <p>Scanne eine Karte mit deiner Kamera und lasse sie automatisch erkennen.</p>
-      </div>
-      <div class="scanner-controls">
-        <button id="startScannerButton" class="primary-button">Kamera starten</button>
-        <button id="captureCardButton" class="secondary" disabled>Karte erfassen</button>
-        <button id="stopScannerButton" class="secondary" disabled>Stoppen</button>
-      </div>
-      <div class="scanner-view">
-        <video id="scannerVideo" autoplay playsinline muted></video>
-        <canvas id="scannerCanvas" hidden></canvas>
-        <div class="scanner-overlay">Platziere die Karte innerhalb des Rahmens</div>
-      </div>
-      <div id="scannerFeedback" class="feedback" role="status" aria-live="polite"></div>
-      <div id="scannerResults" class="card-grid"></div>
+    <section id="deckSection" class="view" data-section="deck" hidden>
+      <article class="panel deck-panel">
+        <div class="panel-header">
+          <h2>Deck-Builder</h2>
+          <p>Erstelle Decks, prüfe Format-Regeln und exportiere Listen.</p>
+        </div>
+        <div class="deck-layout">
+          <aside class="deck-list">
+            <div class="deck-list-header">
+              <h3>Decks</h3>
+              <button id="createDeckButton" type="button" class="primary-button">Neues Deck</button>
+            </div>
+            <ul id="deckList" class="deck-items"></ul>
+          </aside>
+          <section class="deck-detail" aria-live="polite">
+            <div id="deckFeedback" class="feedback" role="status" aria-live="polite"></div>
+            <div id="deckDetail" class="deck-detail-content">
+              <p class="empty-state">Wähle ein Deck oder lege ein neues an.</p>
+            </div>
+          </section>
+        </div>
+      </article>
+    </section>
+
+    <section id="exportSection" class="view" data-section="export" hidden>
+      <article class="panel">
+        <div class="panel-header">
+          <h2>Export &amp; Backups</h2>
+          <p>Lade deine Daten für Versicherung, Handel oder als Sicherungskopie herunter.</p>
+        </div>
+        <div class="export-actions">
+          <button id="exportCollectionCsvButton" type="button" class="primary-button">Sammlung als CSV</button>
+          <button id="exportWishlistCsvButton" type="button" class="secondary">Wunschliste als CSV</button>
+          <button id="exportDeckListButton" type="button" class="secondary">Decklisten als Text</button>
+          <button id="exportJsonButton" type="button" class="secondary">Vollständiges Backup (JSON)</button>
+          <label class="file-import">
+            <input id="importJsonInput" type="file" accept="application/json">
+            <span>Backup importieren</span>
+          </label>
+        </div>
+        <div id="exportFeedback" class="feedback" role="status" aria-live="polite"></div>
+      </article>
+    </section>
+
+    <section id="settingsSection" class="view" data-section="settings" hidden>
+      <article class="panel">
+        <div class="panel-header">
+          <h2>Einstellungen</h2>
+          <p>Passe Darstellung, Währungen und Bewertungsmethoden an.</p>
+        </div>
+        <form id="settingsForm" class="settings-grid">
+          <label class="form-row">
+            <span>Theme</span>
+            <select id="themeSelect" name="theme">
+              <option value="dark">Dunkel</option>
+              <option value="light">Hell</option>
+              <option value="system">System</option>
+            </select>
+          </label>
+          <label class="form-row">
+            <span>Bevorzugte Währung</span>
+            <select id="currencySelect" name="currency">
+              <option value="EUR">Euro (EUR)</option>
+              <option value="USD">US-Dollar (USD)</option>
+              <option value="GBP">Britisches Pfund (GBP)</option>
+            </select>
+          </label>
+          <label class="form-row">
+            <span>Bewertungsmethode</span>
+            <select id="valuationModeSelect" name="valuation">
+              <option value="average">Durchschnittspreis</option>
+              <option value="lowest">Niedrigster Preis</option>
+              <option value="highest">Höchster Preis</option>
+            </select>
+          </label>
+          <label class="form-row">
+            <span>USD → EUR</span>
+            <input id="usdRateInput" name="usdRate" type="number" step="0.0001" min="0" placeholder="0.92">
+          </label>
+          <label class="form-row">
+            <span>GBP → EUR</span>
+            <input id="gbpRateInput" name="gbpRate" type="number" step="0.0001" min="0" placeholder="1.16">
+          </label>
+          <label class="form-row">
+            <span>Preisupdate Intervall (Tage)</span>
+            <input id="priceIntervalInput" name="priceInterval" type="number" min="1" max="30" placeholder="7">
+          </label>
+          <label class="form-row form-row-wide">
+            <span>Notizen</span>
+            <textarea id="settingsNotes" name="notes" placeholder="Platz für persönliche Abläufe, z. B. Versicherungsanforderungen"></textarea>
+          </label>
+        </form>
+        <div class="settings-actions">
+          <button id="updatePricesButton" type="button" class="primary-button">Preise aktualisieren</button>
+          <button id="resetSettingsButton" type="button" class="secondary">Einstellungen zurücksetzen</button>
+          <button id="clearDataButton" type="button" class="secondary danger">Alle Daten löschen</button>
+        </div>
+        <div id="settingsFeedback" class="feedback" role="status" aria-live="polite"></div>
+      </article>
     </section>
   </main>
 
   <footer class="app-footer">
-    <p>Pokémon und Pokémon TCG sind Marken von Nintendo, Creatures und GAME FREAK. Diese App nutzt die <a href="https://pokemontcg.io" target="_blank" rel="noreferrer">Pokémon TCG API</a>.</p>
+    <p>Pokémon und Pokémon TCG sind Marken von Nintendo, Creatures und GAME FREAK. Pokefolio nutzt die <a href="https://pokemontcg.io" target="_blank" rel="noreferrer">Pokémon TCG API</a> und lokale Speicherung, um deine Daten offline verfügbar zu machen.</p>
   </footer>
 
-  <template id="cardTemplate">
-    <article class="card">
+  <dialog id="cardEditorDialog">
+    <form id="cardEditorForm" method="dialog">
+      <header class="dialog-header">
+        <h2 id="cardEditorTitle">Karte hinzufügen</h2>
+        <button type="button" class="secondary" data-dialog-close>Schließen</button>
+      </header>
+      <div class="dialog-body">
+        <div class="card-preview">
+          <img id="cardEditorImage" alt="">
+          <div>
+            <h3 id="cardEditorName"></h3>
+            <p id="cardEditorInfo"></p>
+            <p id="cardEditorPrices" class="dialog-prices"></p>
+          </div>
+        </div>
+        <div class="form-grid">
+          <label>
+            <span>Menge</span>
+            <input type="number" id="cardQuantityInput" name="quantity" min="1" value="1" required>
+          </label>
+          <label>
+            <span>Zustand</span>
+            <select id="cardConditionSelect" name="condition"></select>
+          </label>
+          <label>
+            <span>Sprache</span>
+            <select id="cardLanguageSelect" name="language"></select>
+          </label>
+          <label>
+            <span>Edition</span>
+            <select id="cardEditionSelect" name="edition">
+              <option value="standard">Standard</option>
+              <option value="first">1st Edition</option>
+              <option value="shadowless">Shadowless</option>
+              <option value="promo">Promo</option>
+            </select>
+          </label>
+          <label>
+            <span>Kaufpreis</span>
+            <input type="number" id="purchasePriceInput" name="purchasePrice" min="0" step="0.01" placeholder="z. B. 24.99">
+          </label>
+          <label>
+            <span>Kaufdatum</span>
+            <input type="date" id="purchaseDateInput" name="purchaseDate">
+          </label>
+          <label>
+            <span>Zielpreis / Alarm</span>
+            <input type="number" id="targetPriceInput" name="targetPrice" min="0" step="0.01" placeholder="Optional">
+          </label>
+          <label>
+            <span>Priorität</span>
+            <select id="prioritySelect" name="priority">
+              <option value="high">Must Have</option>
+              <option value="medium">Wichtig</option>
+              <option value="low">Nice to Have</option>
+            </select>
+          </label>
+          <label class="form-row-wide">
+            <span>Notizen</span>
+            <textarea id="cardNotesInput" name="notes" placeholder="z. B. signiert, PSA 9, erhalten bei Turnier"></textarea>
+          </label>
+        </div>
+      </div>
+      <footer class="dialog-actions">
+        <button type="submit" value="save" class="primary-button">Speichern</button>
+      </footer>
+      <input type="hidden" id="cardEditorMode" name="mode" value="collection">
+      <input type="hidden" id="cardEditorCardId" name="cardId">
+    </form>
+  </dialog>
+
+  <dialog id="deckPickerDialog">
+    <form id="deckPickerForm" method="dialog">
+      <header class="dialog-header">
+        <h2>Karte zum Deck hinzufügen</h2>
+        <button type="button" class="secondary" data-dialog-close>Schließen</button>
+      </header>
+      <div class="dialog-body">
+        <p id="deckPickerCardInfo"></p>
+        <label>
+          <span>Deck auswählen</span>
+          <select id="deckPickerSelect" name="deckId"></select>
+        </label>
+        <label>
+          <span>Menge</span>
+          <input type="number" id="deckPickerQuantity" name="quantity" min="1" max="4" value="1">
+        </label>
+        <label>
+          <span>Kategorie</span>
+          <select id="deckPickerCategory" name="category">
+            <option value="main">Hauptdeck</option>
+            <option value="side">Sideboard</option>
+            <option value="extra">Extra Slot</option>
+          </select>
+        </label>
+      </div>
+      <footer class="dialog-actions">
+        <button type="submit" value="save" class="primary-button">Hinzufügen</button>
+      </footer>
+      <input type="hidden" id="deckPickerCardId" name="cardId">
+    </form>
+  </dialog>
+
+  <dialog id="deckEditorDialog">
+    <form id="deckEditorForm" method="dialog">
+      <header class="dialog-header">
+        <h2 id="deckEditorTitle">Deck anlegen</h2>
+        <button type="button" class="secondary" data-dialog-close>Schließen</button>
+      </header>
+      <div class="dialog-body">
+        <label>
+          <span>Deckname</span>
+          <input type="text" id="deckNameInput" name="name" required placeholder="z. B. Lugia VSTAR">
+        </label>
+        <label>
+          <span>Format</span>
+          <select id="deckFormatSelect" name="format">
+            <option value="standard">Standard</option>
+            <option value="expanded">Expanded</option>
+            <option value="unlimited">Unlimited</option>
+            <option value="gym">Gym Leader Challenge</option>
+          </select>
+        </label>
+        <label>
+          <span>Notizen</span>
+          <textarea id="deckNotesInput" name="notes" placeholder="Strategie, Turnierergebnisse, etc."></textarea>
+        </label>
+      </div>
+      <footer class="dialog-actions">
+        <button type="submit" value="save" class="primary-button">Speichern</button>
+      </footer>
+      <input type="hidden" id="deckEditorId" name="deckId">
+    </form>
+  </dialog>
+
+  <template id="cardResultTemplate">
+    <article class="card" data-card-id="">
       <div class="card-image-wrapper">
-        <img alt="" class="card-image" loading="lazy">
+        <img class="card-image" alt="" loading="lazy">
+        <div class="card-badges"></div>
       </div>
       <div class="card-body">
         <h3 class="card-title"></h3>
         <p class="card-subtitle"></p>
-        <p class="card-meta"></p>
+        <ul class="card-meta"></ul>
+        <p class="card-price"></p>
       </div>
       <div class="card-actions">
-        <button class="primary-button add-button">Zur Sammlung</button>
-        <a class="secondary details-link" target="_blank" rel="noreferrer">Details</a>
+        <button type="button" class="primary-button" data-action="add-to-collection">Zur Sammlung</button>
+        <button type="button" class="secondary" data-action="add-to-wishlist">Zur Wunschliste</button>
+        <button type="button" class="secondary" data-action="add-to-deck">Zum Deck</button>
+        <a class="details-link" target="_blank" rel="noreferrer">Details</a>
       </div>
     </article>
+  </template>
+
+  <template id="collectionItemTemplate">
+    <article class="card collection-card" data-card-id="">
+      <div class="card-image-wrapper">
+        <img class="card-image" alt="" loading="lazy">
+        <div class="card-badges"></div>
+      </div>
+      <div class="card-body">
+        <h3 class="card-title"></h3>
+        <p class="card-subtitle"></p>
+        <ul class="card-meta"></ul>
+        <p class="card-price"></p>
+        <p class="card-notes"></p>
+      </div>
+      <div class="card-actions">
+        <button type="button" class="secondary" data-action="edit-entry">Bearbeiten</button>
+        <button type="button" class="secondary" data-action="update-price">Preis aktualisieren</button>
+        <button type="button" class="secondary" data-action="add-to-deck">Zum Deck</button>
+        <button type="button" class="secondary danger" data-action="remove-entry">Entfernen</button>
+      </div>
+    </article>
+  </template>
+
+  <template id="wishlistItemTemplate">
+    <article class="card wishlist-card" data-card-id="">
+      <div class="card-image-wrapper">
+        <img class="card-image" alt="" loading="lazy">
+        <div class="card-badges"></div>
+      </div>
+      <div class="card-body">
+        <h3 class="card-title"></h3>
+        <p class="card-subtitle"></p>
+        <ul class="card-meta"></ul>
+        <p class="card-price"></p>
+        <p class="card-target"></p>
+      </div>
+      <div class="card-actions">
+        <button type="button" class="primary-button" data-action="move-to-collection">In Sammlung übernehmen</button>
+        <button type="button" class="secondary" data-action="edit-wishlist">Bearbeiten</button>
+        <button type="button" class="secondary danger" data-action="remove-wishlist">Entfernen</button>
+      </div>
+    </article>
+  </template>
+
+  <template id="deckListItemTemplate">
+    <li class="deck-item" data-deck-id="">
+      <button type="button" class="deck-select-button"></button>
+      <div class="deck-meta"></div>
+      <div class="deck-actions">
+        <button type="button" data-action="edit-deck">Bearbeiten</button>
+        <button type="button" data-action="delete-deck" class="danger">Löschen</button>
+      </div>
+    </li>
+  </template>
+  
+  <template id="alertTemplate">
+    <div class="alert" data-card-id="">
+      <strong class="alert-title"></strong>
+      <p class="alert-message"></p>
+    </div>
   </template>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pokémon TCG Sammler</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <script defer src="https://cdn.jsdelivr.net/npm/tesseract.js@4/dist/tesseract.min.js"></script>
+  <script type="module" src="script.js" defer></script>
+</head>
+<body>
+  <header class="app-header">
+    <div class="header-content">
+      <h1>Pokémon TCG Sammler</h1>
+      <p>Durchsuche jede Karte, entdecke neue Sets und verwalte deine Sammlung mit Hilfe einer starken Pokémon TCG API.</p>
+    </div>
+    <div class="api-key">
+      <label for="apiKeyInput">API-Schlüssel (optional)</label>
+      <div class="api-key-controls">
+        <input type="text" id="apiKeyInput" placeholder="X-Api-Key hier einfügen">
+        <button id="saveApiKeyButton" class="primary-button">Speichern</button>
+        <button id="clearApiKeyButton" class="secondary">Entfernen</button>
+      </div>
+      <small>Falls du einen eigenen Schlüssel besitzt, erhöht dies das tägliche Limit.</small>
+      <div id="apiKeyFeedback" class="feedback" role="status" aria-live="polite"></div>
+    </div>
+  </header>
+
+  <main>
+    <section id="searchSection" class="panel">
+      <div class="panel-header">
+        <h2>Kartensuche</h2>
+        <p>Nutze die offizielle Pokémon TCG API, um Karten zu finden und deiner Sammlung hinzuzufügen.</p>
+      </div>
+      <form id="searchForm" class="search-form">
+        <div class="form-group">
+          <label for="searchQuery">Name oder Stichwort</label>
+          <input id="searchQuery" name="query" type="search" placeholder="z. B. Pikachu oder Glurak">
+        </div>
+        <div class="form-group">
+          <label for="setFilter">Set</label>
+          <select id="setFilter" name="set">
+            <option value="">Alle Sets</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="typeFilter">Typ</label>
+          <select id="typeFilter" name="type">
+            <option value="">Alle Typen</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="rarityFilter">Seltenheit</label>
+          <select id="rarityFilter" name="rarity">
+            <option value="">Alle Seltenheiten</option>
+          </select>
+        </div>
+        <button type="submit" class="primary-button">Suchen</button>
+      </form>
+      <div id="searchFeedback" class="feedback" role="status" aria-live="polite"></div>
+    </section>
+
+    <section id="setsSection" class="panel">
+      <div class="panel-header">
+        <h2>Aktuelle Sets</h2>
+        <p>Stöbere durch neue und beliebte Sets.</p>
+      </div>
+      <div id="setsGrid" class="set-grid" aria-live="polite"></div>
+    </section>
+
+    <section id="resultsSection" class="panel">
+      <div class="panel-header">
+        <h2>Suchergebnisse</h2>
+        <p>Füge Karten zu deiner Sammlung hinzu oder sieh dir Details an.</p>
+      </div>
+      <div id="resultsGrid" class="card-grid" aria-live="polite"></div>
+    </section>
+
+    <section id="collectionSection" class="panel">
+      <div class="panel-header">
+        <h2>Meine Sammlung</h2>
+        <p>Alles, was du hinzufügst, bleibt lokal auf diesem Gerät gespeichert.</p>
+      </div>
+      <div id="collectionFeedback" class="feedback" role="status" aria-live="polite"></div>
+      <div id="collectionEmptyState" class="empty-state">Noch keine Karten hinzugefügt.</div>
+      <div id="collectionGrid" class="card-grid"></div>
+    </section>
+
+    <section id="scannerSection" class="panel">
+      <div class="panel-header">
+        <h2>Kartenscan</h2>
+        <p>Scanne eine Karte mit deiner Kamera und lasse sie automatisch erkennen.</p>
+      </div>
+      <div class="scanner-controls">
+        <button id="startScannerButton" class="primary-button">Kamera starten</button>
+        <button id="captureCardButton" class="secondary" disabled>Karte erfassen</button>
+        <button id="stopScannerButton" class="secondary" disabled>Stoppen</button>
+      </div>
+      <div class="scanner-view">
+        <video id="scannerVideo" autoplay playsinline muted></video>
+        <canvas id="scannerCanvas" hidden></canvas>
+        <div class="scanner-overlay">Platziere die Karte innerhalb des Rahmens</div>
+      </div>
+      <div id="scannerFeedback" class="feedback" role="status" aria-live="polite"></div>
+      <div id="scannerResults" class="card-grid"></div>
+    </section>
+  </main>
+
+  <footer class="app-footer">
+    <p>Pokémon und Pokémon TCG sind Marken von Nintendo, Creatures und GAME FREAK. Diese App nutzt die <a href="https://pokemontcg.io" target="_blank" rel="noreferrer">Pokémon TCG API</a>.</p>
+  </footer>
+
+  <template id="cardTemplate">
+    <article class="card">
+      <div class="card-image-wrapper">
+        <img alt="" class="card-image" loading="lazy">
+      </div>
+      <div class="card-body">
+        <h3 class="card-title"></h3>
+        <p class="card-subtitle"></p>
+        <p class="card-meta"></p>
+      </div>
+      <div class="card-actions">
+        <button class="primary-button add-button">Zur Sammlung</button>
+        <a class="secondary details-link" target="_blank" rel="noreferrer">Details</a>
+      </div>
+    </article>
+  </template>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,808 @@
+'use strict';
+
+const STORAGE_KEYS = {
+  collection: 'pokemontcg.collection',
+  apiKey: 'pokemontcg.apiKey'
+};
+
+const API_BASE_URL = 'https://api.pokemontcg.io/v2';
+const FEATURED_SET_LIMIT = 12;
+const MAX_SCAN_RESULTS = 8;
+
+const dom = {
+  searchForm: document.getElementById('searchForm'),
+  searchFeedback: document.getElementById('searchFeedback'),
+  setsGrid: document.getElementById('setsGrid'),
+  resultsGrid: document.getElementById('resultsGrid'),
+  collectionGrid: document.getElementById('collectionGrid'),
+  collectionFeedback: document.getElementById('collectionFeedback'),
+  collectionEmptyState: document.getElementById('collectionEmptyState'),
+  setFilter: document.getElementById('setFilter'),
+  typeFilter: document.getElementById('typeFilter'),
+  rarityFilter: document.getElementById('rarityFilter'),
+  apiKeyInput: document.getElementById('apiKeyInput'),
+  apiKeyFeedback: document.getElementById('apiKeyFeedback'),
+  saveApiKeyButton: document.getElementById('saveApiKeyButton'),
+  clearApiKeyButton: document.getElementById('clearApiKeyButton'),
+  scannerVideo: document.getElementById('scannerVideo'),
+  scannerCanvas: document.getElementById('scannerCanvas'),
+  scannerFeedback: document.getElementById('scannerFeedback'),
+  scannerResults: document.getElementById('scannerResults'),
+  startScannerButton: document.getElementById('startScannerButton'),
+  captureCardButton: document.getElementById('captureCardButton'),
+  stopScannerButton: document.getElementById('stopScannerButton')
+};
+
+const state = {
+  apiKey: loadApiKey(),
+  sets: [],
+  collection: loadCollection(),
+  isSearching: false
+};
+
+const scannerState = {
+  stream: null,
+  isActive: false
+};
+
+init();
+
+async function init() {
+  initialiseApiKeyControls();
+  renderCollection();
+  setupSearchForm();
+  setupScanner();
+  await loadSetsAndFilters();
+}
+
+function loadApiKey() {
+  try {
+    return localStorage.getItem(STORAGE_KEYS.apiKey) ?? '';
+  } catch (error) {
+    console.warn('Konnte API-Schlüssel nicht laden.', error);
+    return '';
+  }
+}
+
+function saveApiKey(key) {
+  try {
+    if (key) {
+      localStorage.setItem(STORAGE_KEYS.apiKey, key);
+    } else {
+      localStorage.removeItem(STORAGE_KEYS.apiKey);
+    }
+  } catch (error) {
+    console.warn('Konnte API-Schlüssel nicht speichern.', error);
+  }
+}
+
+function loadCollection() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEYS.collection);
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.map((entry) => ({
+      ...entry,
+      quantity: Number(entry.quantity) || 1
+    }));
+  } catch (error) {
+    console.warn('Konnte Sammlung nicht laden.', error);
+    return [];
+  }
+}
+
+function saveCollection() {
+  try {
+    localStorage.setItem(STORAGE_KEYS.collection, JSON.stringify(state.collection));
+  } catch (error) {
+    console.warn('Konnte Sammlung nicht speichern.', error);
+  }
+}
+
+function initialiseApiKeyControls() {
+  if (state.apiKey) {
+    dom.apiKeyInput.value = state.apiKey;
+    setFeedback(dom.apiKeyFeedback, 'Eigener API-Schlüssel aktiv.', 'success');
+  }
+
+  dom.saveApiKeyButton.addEventListener('click', () => {
+    const key = dom.apiKeyInput.value.trim();
+    state.apiKey = key;
+    saveApiKey(key);
+    setFeedback(dom.apiKeyFeedback, key ? 'API-Schlüssel gespeichert.' : 'Bitte einen gültigen Schlüssel eingeben.', key ? 'success' : 'error');
+  });
+
+  dom.clearApiKeyButton.addEventListener('click', () => {
+    dom.apiKeyInput.value = '';
+    state.apiKey = '';
+    saveApiKey('');
+    setFeedback(dom.apiKeyFeedback, 'API-Schlüssel entfernt. Öffentliche Limits gelten.', 'success');
+  });
+}
+
+async function loadSetsAndFilters() {
+  setFeedback(dom.searchFeedback, 'Lade Sets und Filter …');
+  try {
+    const [setsResponse, typesResponse, raritiesResponse] = await Promise.all([
+      apiFetch('/sets', { orderBy: '-releaseDate', pageSize: 250 }),
+      apiFetch('/types'),
+      apiFetch('/rarities')
+    ]);
+
+    state.sets = Array.isArray(setsResponse?.data) ? setsResponse.data : [];
+    renderSets(state.sets.slice(0, FEATURED_SET_LIMIT));
+    populateSetFilter(state.sets);
+    populateTypeFilter(typesResponse?.data ?? []);
+    populateRarityFilter(raritiesResponse?.data ?? []);
+    setFeedback(dom.searchFeedback, 'Bereit! Starte eine Suche oder scanne eine Karte.');
+  } catch (error) {
+    console.error(error);
+    const message = getErrorMessage(error);
+    setFeedback(dom.searchFeedback, `Sets konnten nicht geladen werden: ${message}`, 'error');
+  }
+}
+
+function populateSetFilter(sets) {
+  if (!dom.setFilter) {
+    return;
+  }
+
+  clearSelectOptions(dom.setFilter, 'Alle Sets');
+  sets.forEach((set) => {
+    const option = document.createElement('option');
+    option.value = set.id;
+    option.textContent = `${set.name} (${set.series})`;
+    dom.setFilter.append(option);
+  });
+}
+
+function populateTypeFilter(types) {
+  if (!dom.typeFilter) {
+    return;
+  }
+
+  clearSelectOptions(dom.typeFilter, 'Alle Typen');
+  types.forEach((type) => {
+    const option = document.createElement('option');
+    option.value = type;
+    option.textContent = type;
+    dom.typeFilter.append(option);
+  });
+}
+
+function populateRarityFilter(rarities) {
+  if (!dom.rarityFilter) {
+    return;
+  }
+
+  clearSelectOptions(dom.rarityFilter, 'Alle Seltenheiten');
+  rarities.forEach((rarity) => {
+    const option = document.createElement('option');
+    option.value = rarity;
+    option.textContent = rarity;
+    dom.rarityFilter.append(option);
+  });
+}
+
+function clearSelectOptions(selectElement, placeholder) {
+  selectElement.innerHTML = '';
+  const option = document.createElement('option');
+  option.value = '';
+  option.textContent = placeholder;
+  selectElement.append(option);
+}
+
+function renderSets(sets) {
+  dom.setsGrid.innerHTML = '';
+  if (!sets.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.textContent = 'Keine Sets gefunden.';
+    dom.setsGrid.append(empty);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  sets.forEach((set) => {
+    fragment.append(createSetCard(set));
+  });
+  dom.setsGrid.append(fragment);
+}
+
+function createSetCard(set) {
+  const element = document.createElement('article');
+  element.className = 'set-card';
+
+  const image = document.createElement('img');
+  image.src = set.images?.symbol || set.images?.logo || '';
+  image.alt = `${set.name} Symbol`;
+  element.append(image);
+
+  const info = document.createElement('div');
+  const title = document.createElement('h3');
+  title.textContent = set.name;
+  info.append(title);
+
+  const details = document.createElement('p');
+  const date = formatDate(set.releaseDate);
+  const total = `${set.total || '?'} Karten`;
+  details.textContent = `${set.series} · ${total}${date ? ` · ${date}` : ''}`;
+  info.append(details);
+
+  const action = document.createElement('button');
+  action.type = 'button';
+  action.className = 'secondary';
+  action.textContent = 'Im Suchfilter wählen';
+  action.addEventListener('click', () => {
+    dom.setFilter.value = set.id;
+    if (dom.searchForm?.requestSubmit) {
+      dom.searchForm.requestSubmit();
+    } else {
+      dom.searchForm?.dispatchEvent(new Event('submit'));
+    }
+  });
+  info.append(action);
+
+  element.append(info);
+  return element;
+}
+
+function setupSearchForm() {
+  if (!dom.searchForm) {
+    return;
+  }
+
+  dom.searchForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (state.isSearching) {
+      return;
+    }
+
+    const formData = new FormData(dom.searchForm);
+    const query = (formData.get('query') || '').toString().trim();
+    const setId = (formData.get('set') || '').toString().trim();
+    const type = (formData.get('type') || '').toString().trim();
+    const rarity = (formData.get('rarity') || '').toString().trim();
+
+    const clauses = [];
+    if (query) {
+      const escaped = escapeQueryValue(query);
+      clauses.push(`(name:*\"${escaped}\"* OR subtypes:*\"${escaped}\"*)`);
+    }
+    if (setId) {
+      clauses.push(`set.id:${setId}`);
+    }
+    if (type) {
+      clauses.push(`types:${type}`);
+    }
+    if (rarity) {
+      clauses.push(`rarity:\"${escapeQueryValue(rarity)}\"`);
+    }
+
+    const searchParams = new URLSearchParams({
+      pageSize: '40',
+      orderBy: 'name'
+    });
+
+    if (clauses.length) {
+      searchParams.set('q', clauses.join(' AND '));
+    }
+
+    await performCardSearch(searchParams, query);
+  });
+}
+
+async function performCardSearch(searchParams, queryText) {
+  state.isSearching = true;
+  setFeedback(dom.searchFeedback, 'Suche Karten …');
+  try {
+    const response = await apiFetch('/cards', searchParams);
+    const cards = response?.data ?? [];
+    renderCardList(cards, dom.resultsGrid, {
+      emptyMessage: queryText ? 'Keine Karten für die Suche gefunden.' : 'Bitte starte eine Suche, um Karten zu sehen.',
+      feedbackElement: dom.searchFeedback
+    });
+    if (cards.length) {
+      setFeedback(dom.searchFeedback, `${cards.length} Karten gefunden.`);
+    } else {
+      setFeedback(dom.searchFeedback, 'Keine passenden Karten gefunden.', 'error');
+    }
+  } catch (error) {
+    console.error(error);
+    const message = getErrorMessage(error);
+    setFeedback(dom.searchFeedback, `Suche fehlgeschlagen: ${message}`, 'error');
+  } finally {
+    state.isSearching = false;
+  }
+}
+
+function renderCardList(cards, container, options = {}) {
+  const { emptyMessage, feedbackElement } = options;
+  container.innerHTML = '';
+
+  if (!cards.length) {
+    if (emptyMessage) {
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.textContent = emptyMessage;
+      container.append(empty);
+    }
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  cards.forEach((card) => {
+    const element = createCardElement(card, {
+      onAdd: (addedCard) => {
+        const { action } = addCardToCollection(addedCard);
+        if (feedbackElement) {
+          const message = action === 'new'
+            ? `${addedCard.name} wurde deiner Sammlung hinzugefügt.`
+            : `Anzahl von ${addedCard.name} erhöht.`;
+          setFeedback(feedbackElement, message, 'success');
+        }
+      }
+    });
+    fragment.append(element);
+  });
+  container.append(fragment);
+}
+
+function createCardElement(card, options = {}) {
+  const template = document.getElementById('cardTemplate');
+  if (!template) {
+    throw new Error('Kartenvorlage fehlt');
+  }
+
+  const { onAdd } = options;
+  const element = template.content.firstElementChild.cloneNode(true);
+  const image = element.querySelector('.card-image');
+  image.src = card.images?.small || card.images?.large || '';
+  image.alt = `${card.name} (${card.set?.name ?? 'Pokémon TCG'})`;
+
+  element.querySelector('.card-title').textContent = card.name;
+  element.querySelector('.card-subtitle').textContent = card.set ? `${card.set.series} · ${card.set.name}` : 'Pokémon TCG Karte';
+  const metaParts = [];
+  if (card.number) {
+    metaParts.push(`Nr. ${card.number}`);
+  }
+  if (card.rarity) {
+    metaParts.push(card.rarity);
+  }
+  if (card.types?.length) {
+    metaParts.push(card.types.join(', '));
+  }
+  element.querySelector('.card-meta').textContent = metaParts.join(' · ');
+
+  const addButton = element.querySelector('.add-button');
+  if (addButton) {
+    addButton.addEventListener('click', () => {
+      if (typeof onAdd === 'function') {
+        onAdd(card);
+      }
+    });
+  }
+
+  const detailsLink = element.querySelector('.details-link');
+  if (detailsLink) {
+    detailsLink.href = createDetailsUrl(card.id);
+    detailsLink.textContent = 'Details anzeigen';
+  }
+
+  return element;
+}
+
+function createDetailsUrl(cardId) {
+  return `https://pokemontcg.io/card/${cardId}`;
+}
+
+function toCollectionEntry(card) {
+  return {
+    id: card.id,
+    name: card.name,
+    number: card.number ?? '',
+    setName: card.set?.name ?? '',
+    setSeries: card.set?.series ?? '',
+    rarity: card.rarity ?? '',
+    types: card.types ?? [],
+    images: card.images ?? {},
+    url: createDetailsUrl(card.id),
+    quantity: 1
+  };
+}
+
+function addCardToCollection(card) {
+  const existing = state.collection.find((entry) => entry.id === card.id);
+  if (existing) {
+    existing.quantity += 1;
+    saveCollection();
+    renderCollection();
+    setFeedback(dom.collectionFeedback, `${existing.name} aktualisiert.`, 'success');
+    return { action: 'increment', entry: existing };
+  }
+
+  const entry = toCollectionEntry(card);
+  state.collection.push(entry);
+  saveCollection();
+  renderCollection();
+  setFeedback(dom.collectionFeedback, `${entry.name} wurde zur Sammlung hinzugefügt.`, 'success');
+  return { action: 'new', entry };
+}
+
+function renderCollection() {
+  dom.collectionGrid.innerHTML = '';
+  if (!state.collection.length) {
+    dom.collectionEmptyState.style.display = 'block';
+    setFeedback(dom.collectionFeedback, '');
+    return;
+  }
+
+  dom.collectionEmptyState.style.display = 'none';
+  const sorted = [...state.collection].sort((a, b) => a.name.localeCompare(b.name, 'de'));
+  const fragment = document.createDocumentFragment();
+  sorted.forEach((entry) => {
+    fragment.append(createCollectionCard(entry));
+  });
+  dom.collectionGrid.append(fragment);
+}
+
+function createCollectionCard(entry) {
+  const template = document.getElementById('cardTemplate');
+  const element = template.content.firstElementChild.cloneNode(true);
+  const image = element.querySelector('.card-image');
+  image.src = entry.images?.small || entry.images?.large || '';
+  image.alt = `${entry.name} (${entry.setName || 'Pokémon TCG'})`;
+
+  element.querySelector('.card-title').textContent = entry.name;
+  const subtitleParts = [];
+  if (entry.setSeries) {
+    subtitleParts.push(entry.setSeries);
+  }
+  if (entry.setName) {
+    subtitleParts.push(entry.setName);
+  }
+  element.querySelector('.card-subtitle').textContent = subtitleParts.join(' · ');
+
+  const metaParts = [];
+  if (entry.number) {
+    metaParts.push(`Nr. ${entry.number}`);
+  }
+  if (entry.rarity) {
+    metaParts.push(entry.rarity);
+  }
+  if (entry.types?.length) {
+    metaParts.push(entry.types.join(', '));
+  }
+  metaParts.push(`Anzahl: ${entry.quantity}`);
+  element.querySelector('.card-meta').textContent = metaParts.join(' · ');
+
+  const detailsLink = element.querySelector('.details-link');
+  detailsLink.href = entry.url;
+  detailsLink.textContent = 'Details anzeigen';
+
+  const addButton = element.querySelector('.add-button');
+  if (addButton) {
+    addButton.remove();
+  }
+
+  const actions = element.querySelector('.card-actions');
+  const quantityControls = document.createElement('div');
+  quantityControls.className = 'quantity-controls';
+
+  const decrementButton = document.createElement('button');
+  decrementButton.type = 'button';
+  decrementButton.className = 'quantity-button';
+  decrementButton.textContent = '−';
+  decrementButton.addEventListener('click', () => updateCollectionQuantity(entry.id, -1));
+
+  const quantityValue = document.createElement('span');
+  quantityValue.className = 'quantity-value';
+  quantityValue.textContent = entry.quantity;
+
+  const incrementButton = document.createElement('button');
+  incrementButton.type = 'button';
+  incrementButton.className = 'quantity-button';
+  incrementButton.textContent = '+';
+  incrementButton.addEventListener('click', () => updateCollectionQuantity(entry.id, 1));
+
+  quantityControls.append(decrementButton, quantityValue, incrementButton);
+  actions.prepend(quantityControls);
+
+  const removeButton = document.createElement('button');
+  removeButton.type = 'button';
+  removeButton.className = 'secondary remove-button';
+  removeButton.textContent = 'Entfernen';
+  removeButton.addEventListener('click', () => removeCardFromCollection(entry.id));
+  actions.append(removeButton);
+
+  return element;
+}
+
+function updateCollectionQuantity(cardId, delta) {
+  const entry = state.collection.find((item) => item.id === cardId);
+  if (!entry) {
+    return;
+  }
+
+  entry.quantity = Math.max(0, entry.quantity + delta);
+  if (entry.quantity <= 0) {
+    removeCardFromCollection(cardId);
+    return;
+  }
+
+  saveCollection();
+  renderCollection();
+  setFeedback(dom.collectionFeedback, `Anzahl von ${entry.name} aktualisiert.`, 'success');
+}
+
+function removeCardFromCollection(cardId) {
+  const index = state.collection.findIndex((item) => item.id === cardId);
+  if (index === -1) {
+    return;
+  }
+  const [removed] = state.collection.splice(index, 1);
+  saveCollection();
+  renderCollection();
+  setFeedback(dom.collectionFeedback, `${removed.name} wurde aus der Sammlung entfernt.`, 'success');
+}
+
+function setupScanner() {
+  if (!dom.startScannerButton) {
+    return;
+  }
+
+  dom.startScannerButton.addEventListener('click', () => startScanner());
+  dom.stopScannerButton.addEventListener('click', () => stopScanner());
+  dom.captureCardButton.addEventListener('click', () => captureCard());
+}
+
+async function startScanner() {
+  if (!navigator.mediaDevices?.getUserMedia) {
+    setFeedback(dom.scannerFeedback, 'Kamera wird nicht unterstützt. Verwende stattdessen die Suche.', 'error');
+    return;
+  }
+
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({
+      video: { facingMode: 'environment' },
+      audio: false
+    });
+    scannerState.stream = stream;
+    scannerState.isActive = true;
+    dom.scannerVideo.srcObject = stream;
+    dom.captureCardButton.disabled = false;
+    dom.stopScannerButton.disabled = false;
+    dom.startScannerButton.disabled = true;
+    setFeedback(dom.scannerFeedback, 'Kamera aktiv. Positioniere die Karte im Rahmen.');
+  } catch (error) {
+    console.error('Scanner konnte nicht gestartet werden', error);
+    setFeedback(dom.scannerFeedback, `Kamera konnte nicht gestartet werden: ${getErrorMessage(error)}`, 'error');
+  }
+}
+
+function stopScanner() {
+  if (scannerState.stream) {
+    scannerState.stream.getTracks().forEach((track) => track.stop());
+  }
+  scannerState.stream = null;
+  scannerState.isActive = false;
+  dom.scannerVideo.srcObject = null;
+  dom.captureCardButton.disabled = true;
+  dom.stopScannerButton.disabled = true;
+  dom.startScannerButton.disabled = false;
+  setFeedback(dom.scannerFeedback, 'Kamera gestoppt.');
+}
+
+async function captureCard() {
+  if (!scannerState.isActive || !scannerState.stream) {
+    setFeedback(dom.scannerFeedback, 'Starte zuerst die Kamera.', 'error');
+    return;
+  }
+
+  if (!window.Tesseract) {
+    setFeedback(dom.scannerFeedback, 'Tesseract.js konnte nicht geladen werden.', 'error');
+    return;
+  }
+
+  const video = dom.scannerVideo;
+  if (!video.videoWidth || !video.videoHeight) {
+    setFeedback(dom.scannerFeedback, 'Video wird noch geladen. Bitte versuche es erneut.', 'error');
+    return;
+  }
+
+  const canvas = dom.scannerCanvas;
+  canvas.width = video.videoWidth;
+  canvas.height = video.videoHeight;
+  const context = canvas.getContext('2d');
+  context.drawImage(video, 0, 0, canvas.width, canvas.height);
+
+  dom.captureCardButton.disabled = true;
+  setFeedback(dom.scannerFeedback, 'Analysiere Karte …');
+
+  try {
+    const result = await window.Tesseract.recognize(canvas, 'eng', {
+      logger: (message) => {
+        if (message.status === 'recognizing text') {
+          const progress = Math.round((message.progress || 0) * 100);
+          setFeedback(dom.scannerFeedback, `Erkenne Text … ${progress}%`);
+        }
+      }
+    });
+
+    const recognizedText = result?.data?.text?.trim();
+    if (!recognizedText) {
+      setFeedback(dom.scannerFeedback, 'Keine Schrift erkannt. Bitte versuche es noch einmal.', 'error');
+      dom.captureCardButton.disabled = false;
+      return;
+    }
+
+    setFeedback(dom.scannerFeedback, 'Text erkannt. Suche nach passenden Karten …');
+    const cards = await findCardsByOcr(recognizedText);
+    if (cards.length) {
+      renderCardList(cards.slice(0, MAX_SCAN_RESULTS), dom.scannerResults, {
+        feedbackElement: dom.scannerFeedback
+      });
+      setFeedback(dom.scannerFeedback, `${cards.length} mögliche Karten gefunden.`, 'success');
+    } else {
+      dom.scannerResults.innerHTML = '';
+      setFeedback(dom.scannerFeedback, 'Keine passenden Karten gefunden.', 'error');
+    }
+  } catch (error) {
+    console.error('Scan fehlgeschlagen', error);
+    setFeedback(dom.scannerFeedback, `Analyse fehlgeschlagen: ${getErrorMessage(error)}`, 'error');
+  } finally {
+    dom.captureCardButton.disabled = false;
+  }
+}
+
+async function findCardsByOcr(text) {
+  const sanitized = text
+    .replace(/[|*_=\[\]{}<>]/g, ' ')
+    .replace(/[^\w\s/.-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!sanitized) {
+    return [];
+  }
+
+  const tokens = sanitized.split(' ').filter((token) => token.length > 2);
+  const phrases = buildCandidatePhrases(tokens);
+  const uniqueResults = new Map();
+
+  for (const phrase of phrases) {
+    if (uniqueResults.size >= MAX_SCAN_RESULTS) {
+      break;
+    }
+
+    try {
+      const params = new URLSearchParams({
+        q: `name:\"${escapeQueryValue(phrase)}\"`,
+        pageSize: '6'
+      });
+      const response = await apiFetch('/cards', params);
+      const cards = response?.data ?? [];
+      cards.forEach((card) => {
+        if (!uniqueResults.has(card.id)) {
+          uniqueResults.set(card.id, card);
+        }
+      });
+    } catch (error) {
+      console.warn('Fehler bei OCR-Suche', phrase, error);
+    }
+  }
+
+  if (!uniqueResults.size) {
+    const numberMatch = sanitized.match(/\b(\d{1,3})\s*\/\s*\d{1,3}\b/);
+    if (numberMatch) {
+      const number = numberMatch[1];
+      try {
+        const params = new URLSearchParams({
+          q: `number:${number}`,
+          pageSize: '10'
+        });
+        const response = await apiFetch('/cards', params);
+        (response?.data ?? []).forEach((card) => {
+          if (!uniqueResults.has(card.id)) {
+            uniqueResults.set(card.id, card);
+          }
+        });
+      } catch (error) {
+        console.warn('Fehler bei Nummernsuche', error);
+      }
+    }
+  }
+
+  return Array.from(uniqueResults.values());
+}
+
+function buildCandidatePhrases(tokens) {
+  const phrases = new Set();
+  for (let size = Math.min(3, tokens.length); size >= 1; size -= 1) {
+    for (let index = 0; index <= tokens.length - size; index += 1) {
+      const phrase = tokens.slice(index, index + size).join(' ');
+      if (phrase.length >= 3 && !/^\d+$/.test(phrase)) {
+        phrases.add(phrase);
+      }
+    }
+  }
+
+  return Array.from(phrases).sort((a, b) => b.length - a.length).slice(0, 15);
+}
+
+async function apiFetch(endpoint, params) {
+  const url = new URL(`${API_BASE_URL}${endpoint}`);
+  if (params instanceof URLSearchParams) {
+    params.forEach((value, key) => {
+      if (value !== undefined && value !== null && value !== '') {
+        url.searchParams.set(key, value);
+      }
+    });
+  } else if (params && typeof params === 'object') {
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== '') {
+        url.searchParams.set(key, value);
+      }
+    });
+  }
+
+  const headers = {
+    Accept: 'application/json'
+  };
+  if (state.apiKey) {
+    headers['X-Api-Key'] = state.apiKey;
+  }
+
+  const response = await fetch(url.toString(), { headers });
+  if (!response.ok) {
+    let errorMessage = `${response.status} ${response.statusText}`;
+    if (response.status === 403) {
+      errorMessage = 'Zugriff verweigert. Bitte trage deinen API-Schlüssel ein.';
+    }
+    throw new Error(errorMessage);
+  }
+
+  return response.json();
+}
+
+function escapeQueryValue(value) {
+  return value.replace(/"/g, '\\"');
+}
+
+function formatDate(dateString) {
+  if (!dateString) {
+    return '';
+  }
+
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  return new Intl.DateTimeFormat('de-DE', { year: 'numeric', month: 'short' }).format(date);
+}
+
+function getErrorMessage(error) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return typeof error === 'string' ? error : 'Unbekannter Fehler';
+}
+
+function setFeedback(element, message, type) {
+  if (!element) {
+    return;
+  }
+  element.textContent = message || '';
+  element.classList.remove('error', 'success');
+  if (type) {
+    element.classList.add(type);
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,63 +1,2147 @@
 'use strict';
 
-const STORAGE_KEYS = {
+const API_BASE_URL = 'https://api.pokemontcg.io/v2';
+const FEATURED_SET_LIMIT = 18;
+const MAX_SCAN_RESULTS = 10;
+const LEGACY_STORAGE_KEYS = {
   collection: 'pokemontcg.collection',
   apiKey: 'pokemontcg.apiKey'
 };
-
-const API_BASE_URL = 'https://api.pokemontcg.io/v2';
-const FEATURED_SET_LIMIT = 12;
-const MAX_SCAN_RESULTS = 8;
-
-const dom = {
-  searchForm: document.getElementById('searchForm'),
-  searchFeedback: document.getElementById('searchFeedback'),
-  setsGrid: document.getElementById('setsGrid'),
-  resultsGrid: document.getElementById('resultsGrid'),
-  collectionGrid: document.getElementById('collectionGrid'),
-  collectionFeedback: document.getElementById('collectionFeedback'),
-  collectionEmptyState: document.getElementById('collectionEmptyState'),
-  setFilter: document.getElementById('setFilter'),
-  typeFilter: document.getElementById('typeFilter'),
-  rarityFilter: document.getElementById('rarityFilter'),
-  apiKeyInput: document.getElementById('apiKeyInput'),
-  apiKeyFeedback: document.getElementById('apiKeyFeedback'),
-  saveApiKeyButton: document.getElementById('saveApiKeyButton'),
-  clearApiKeyButton: document.getElementById('clearApiKeyButton'),
-  scannerVideo: document.getElementById('scannerVideo'),
-  scannerCanvas: document.getElementById('scannerCanvas'),
-  scannerFeedback: document.getElementById('scannerFeedback'),
-  scannerResults: document.getElementById('scannerResults'),
-  startScannerButton: document.getElementById('startScannerButton'),
-  captureCardButton: document.getElementById('captureCardButton'),
-  stopScannerButton: document.getElementById('stopScannerButton')
+const STORAGE_KEYS = {
+  collection: 'pokefolio.collection.v2',
+  wishlist: 'pokefolio.wishlist.v1',
+  decks: 'pokefolio.decks.v1',
+  settings: 'pokefolio.settings.v1',
+  apiKey: 'pokefolio.apiKey.v1'
+};
+const DEFAULT_SETTINGS = {
+  theme: 'dark',
+  currency: 'EUR',
+  valuationMode: 'average',
+  exchangeRates: {
+    USD: 0.92,
+    GBP: 1.16
+  },
+  priceIntervalDays: 7,
+  lastPriceUpdate: null,
+  notes: ''
+};
+const CONDITION_OPTIONS = [
+  { value: 'mint', label: 'Mint' },
+  { value: 'nearMint', label: 'Near Mint' },
+  { value: 'lightPlay', label: 'Light Play' },
+  { value: 'moderatePlay', label: 'Moderate Play' },
+  { value: 'heavyPlay', label: 'Heavy Play' },
+  { value: 'damaged', label: 'Damaged' }
+];
+const LANGUAGE_OPTIONS = [
+  'Deutsch',
+  'Englisch',
+  'Japanisch',
+  'Französisch',
+  'Italienisch',
+  'Spanisch',
+  'Portugiesisch',
+  'Koreanisch'
+];
+const REGULATION_MARKS = ['D', 'E', 'F', 'G', 'H'];
+const PRIORITY_LABELS = {
+  high: 'Must Have',
+  medium: 'Wichtig',
+  low: 'Nice to Have'
+};
+const CATEGORY_LABELS = {
+  main: 'Hauptdeck',
+  side: 'Sideboard',
+  extra: 'Extra'
 };
 
+const cardCache = new Map();
+
+const dom = {};
 const state = {
-  apiKey: loadApiKey(),
+  apiKey: '',
+  settings: { ...DEFAULT_SETTINGS },
+  collection: [],
+  wishlist: [],
+  decks: [],
   sets: [],
-  collection: loadCollection(),
-  isSearching: false
+  series: [],
+  typeOptions: [],
+  rarityOptions: [],
+  supertypeOptions: [],
+  activeSection: 'search',
+  selectedDeckId: null,
+  searchResults: [],
+  isSearching: false,
+  scanner: {
+    stream: null,
+    isActive: false
+  }
 };
 
-const scannerState = {
-  stream: null,
-  isActive: false
-};
-
-init();
+init().catch((error) => {
+  console.error('Fehler bei der Initialisierung', error);
+  showGlobalFeedback(`Beim Start ist ein Fehler aufgetreten: ${getErrorMessage(error)}`, 'error');
+});
 
 async function init() {
-  initialiseApiKeyControls();
+  cacheDom();
+  loadState();
+  applyTheme();
+  populateStaticOptions();
+  bindGlobalEvents();
+  renderAll();
+  await loadReferenceData();
   renderCollection();
-  setupSearchForm();
-  setupScanner();
-  await loadSetsAndFilters();
+  renderWishlist();
+  renderDeckList();
+  renderDeckDetail();
+  renderDashboard();
+  maybeSchedulePriceRefresh();
+}
+
+function cacheDom() {
+  dom.body = document.body;
+  dom.navButtons = document.querySelectorAll('.nav-button[data-section]');
+  dom.views = document.querySelectorAll('.view[data-section]');
+
+  dom.apiKeyInput = document.getElementById('apiKeyInput');
+  dom.saveApiKeyButton = document.getElementById('saveApiKeyButton');
+  dom.clearApiKeyButton = document.getElementById('clearApiKeyButton');
+  dom.apiKeyFeedback = document.getElementById('apiKeyFeedback');
+
+  dom.searchForm = document.getElementById('searchForm');
+  dom.resetSearchButton = document.getElementById('resetSearchButton');
+  dom.searchFeedback = document.getElementById('searchFeedback');
+  dom.resultsGrid = document.getElementById('resultsGrid');
+  dom.setsGrid = document.getElementById('setsGrid');
+  dom.scannerFeedback = document.getElementById('scannerFeedback');
+  dom.scannerResults = document.getElementById('scannerResults');
+  dom.scannerVideo = document.getElementById('scannerVideo');
+  dom.scannerCanvas = document.getElementById('scannerCanvas');
+  dom.startScannerButton = document.getElementById('startScannerButton');
+  dom.captureCardButton = document.getElementById('captureCardButton');
+  dom.stopScannerButton = document.getElementById('stopScannerButton');
+
+  dom.setFilter = document.getElementById('setFilter');
+  dom.seriesFilter = document.getElementById('seriesFilter');
+  dom.typeFilter = document.getElementById('typeFilter');
+  dom.supertypeFilter = document.getElementById('supertypeFilter');
+  dom.rarityFilter = document.getElementById('rarityFilter');
+  dom.regulationFilter = document.getElementById('regulationFilter');
+  dom.artistFilter = document.getElementById('artistFilter');
+  dom.yearFilter = document.getElementById('yearFilter');
+  dom.sortOrder = document.getElementById('sortOrder');
+
+  dom.collectionFilterForm = document.getElementById('collectionFilterForm');
+  dom.collectionSetFilter = document.getElementById('collectionSetFilter');
+  dom.collectionSeriesFilter = document.getElementById('collectionSeriesFilter');
+  dom.collectionRarityFilter = document.getElementById('collectionRarityFilter');
+  dom.collectionTypeFilter = document.getElementById('collectionTypeFilter');
+  dom.collectionConditionFilter = document.getElementById('collectionConditionFilter');
+  dom.collectionLanguageFilter = document.getElementById('collectionLanguageFilter');
+  dom.collectionSort = document.getElementById('collectionSort');
+  dom.collectionSummary = document.getElementById('collectionSummary');
+  dom.collectionFeedback = document.getElementById('collectionFeedback');
+  dom.collectionEmptyState = document.getElementById('collectionEmptyState');
+  dom.collectionGrid = document.getElementById('collectionGrid');
+
+  dom.dashboardOverview = document.getElementById('dashboardOverview');
+  dom.setProgressList = document.getElementById('setProgressList');
+  dom.rarityDistribution = document.getElementById('rarityDistribution');
+  dom.conditionDistribution = document.getElementById('conditionDistribution');
+  dom.alertsList = document.getElementById('alertsList');
+
+  dom.wishlistFeedback = document.getElementById('wishlistFeedback');
+  dom.wishlistEmptyState = document.getElementById('wishlistEmptyState');
+  dom.wishlistGrid = document.getElementById('wishlistGrid');
+
+  dom.deckFeedback = document.getElementById('deckFeedback');
+  dom.deckList = document.getElementById('deckList');
+  dom.deckDetail = document.getElementById('deckDetail');
+  dom.createDeckButton = document.getElementById('createDeckButton');
+
+  dom.exportCollectionCsvButton = document.getElementById('exportCollectionCsvButton');
+  dom.exportWishlistCsvButton = document.getElementById('exportWishlistCsvButton');
+  dom.exportDeckListButton = document.getElementById('exportDeckListButton');
+  dom.exportJsonButton = document.getElementById('exportJsonButton');
+  dom.importJsonInput = document.getElementById('importJsonInput');
+  dom.exportFeedback = document.getElementById('exportFeedback');
+
+  dom.settingsForm = document.getElementById('settingsForm');
+  dom.themeSelect = document.getElementById('themeSelect');
+  dom.currencySelect = document.getElementById('currencySelect');
+  dom.valuationModeSelect = document.getElementById('valuationModeSelect');
+  dom.usdRateInput = document.getElementById('usdRateInput');
+  dom.gbpRateInput = document.getElementById('gbpRateInput');
+  dom.priceIntervalInput = document.getElementById('priceIntervalInput');
+  dom.settingsNotes = document.getElementById('settingsNotes');
+  dom.settingsFeedback = document.getElementById('settingsFeedback');
+  dom.updatePricesButton = document.getElementById('updatePricesButton');
+  dom.resetSettingsButton = document.getElementById('resetSettingsButton');
+  dom.clearDataButton = document.getElementById('clearDataButton');
+
+  dom.cardEditorDialog = document.getElementById('cardEditorDialog');
+  dom.cardEditorForm = document.getElementById('cardEditorForm');
+  dom.cardEditorTitle = document.getElementById('cardEditorTitle');
+  dom.cardEditorImage = document.getElementById('cardEditorImage');
+  dom.cardEditorName = document.getElementById('cardEditorName');
+  dom.cardEditorInfo = document.getElementById('cardEditorInfo');
+  dom.cardEditorPrices = document.getElementById('cardEditorPrices');
+  dom.cardEditorCardId = document.getElementById('cardEditorCardId');
+  dom.cardEditorMode = document.getElementById('cardEditorMode');
+  dom.cardQuantityInput = document.getElementById('cardQuantityInput');
+  dom.cardConditionSelect = document.getElementById('cardConditionSelect');
+  dom.cardLanguageSelect = document.getElementById('cardLanguageSelect');
+  dom.cardEditionSelect = document.getElementById('cardEditionSelect');
+  dom.purchasePriceInput = document.getElementById('purchasePriceInput');
+  dom.purchaseDateInput = document.getElementById('purchaseDateInput');
+  dom.targetPriceInput = document.getElementById('targetPriceInput');
+  dom.prioritySelect = document.getElementById('prioritySelect');
+  dom.cardNotesInput = document.getElementById('cardNotesInput');
+
+  dom.deckPickerDialog = document.getElementById('deckPickerDialog');
+  dom.deckPickerForm = document.getElementById('deckPickerForm');
+  dom.deckPickerCardInfo = document.getElementById('deckPickerCardInfo');
+  dom.deckPickerSelect = document.getElementById('deckPickerSelect');
+  dom.deckPickerQuantity = document.getElementById('deckPickerQuantity');
+  dom.deckPickerCategory = document.getElementById('deckPickerCategory');
+  dom.deckPickerCardId = document.getElementById('deckPickerCardId');
+
+  dom.deckEditorDialog = document.getElementById('deckEditorDialog');
+  dom.deckEditorForm = document.getElementById('deckEditorForm');
+  dom.deckEditorTitle = document.getElementById('deckEditorTitle');
+  dom.deckNameInput = document.getElementById('deckNameInput');
+  dom.deckFormatSelect = document.getElementById('deckFormatSelect');
+  dom.deckNotesInput = document.getElementById('deckNotesInput');
+  dom.deckEditorId = document.getElementById('deckEditorId');
+
+  dom.cardResultTemplate = document.getElementById('cardResultTemplate');
+  dom.collectionItemTemplate = document.getElementById('collectionItemTemplate');
+  dom.wishlistItemTemplate = document.getElementById('wishlistItemTemplate');
+  dom.deckListItemTemplate = document.getElementById('deckListItemTemplate');
+  dom.alertTemplate = document.getElementById('alertTemplate');
+
+  dom.dialogCloseButtons = document.querySelectorAll('[data-dialog-close]');
+}
+
+function loadState() {
+  state.apiKey = loadApiKey();
+  state.settings = loadSettings();
+  state.collection = loadCollection();
+  state.wishlist = loadWishlist();
+  state.decks = loadDecks();
+
+  if (dom.apiKeyInput) {
+    dom.apiKeyInput.value = state.apiKey;
+    if (state.apiKey) {
+      setFeedback(dom.apiKeyFeedback, 'Eigener API-Schlüssel aktiv.', 'success');
+    }
+  }
+
+  dom.themeSelect.value = state.settings.theme;
+  dom.currencySelect.value = state.settings.currency;
+  dom.valuationModeSelect.value = state.settings.valuationMode;
+  dom.usdRateInput.value = state.settings.exchangeRates.USD ?? '';
+  dom.gbpRateInput.value = state.settings.exchangeRates.GBP ?? '';
+  dom.priceIntervalInput.value = state.settings.priceIntervalDays ?? '';
+  dom.settingsNotes.value = state.settings.notes ?? '';
+}
+
+function populateStaticOptions() {
+  if (dom.cardConditionSelect) {
+    dom.cardConditionSelect.innerHTML = CONDITION_OPTIONS
+      .map((option) => `<option value="${option.value}">${option.label}</option>`)
+      .join('');
+  }
+  if (dom.collectionConditionFilter) {
+    dom.collectionConditionFilter.innerHTML = '<option value="">Alle</option>' + CONDITION_OPTIONS
+      .map((option) => `<option value="${option.value}">${option.label}</option>`)
+      .join('');
+  }
+  if (dom.cardLanguageSelect) {
+    dom.cardLanguageSelect.innerHTML = LANGUAGE_OPTIONS
+      .map((language) => `<option value="${language}">${language}</option>`)
+      .join('');
+  }
+  if (dom.collectionLanguageFilter) {
+    dom.collectionLanguageFilter.innerHTML = '<option value="">Alle</option>' + LANGUAGE_OPTIONS
+      .map((language) => `<option value="${language}">${language}</option>`)
+      .join('');
+  }
+  if (dom.regulationFilter) {
+    dom.regulationFilter.innerHTML = '<option value="">Alle</option>' + REGULATION_MARKS
+      .map((mark) => `<option value="${mark}">${mark}</option>`)
+      .join('');
+  }
+}
+
+function bindGlobalEvents() {
+  dom.navButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const section = button.dataset.section;
+      if (section) {
+        switchSection(section);
+      }
+    });
+  });
+
+  dom.dialogCloseButtons.forEach((button) => {
+    button.addEventListener('click', (event) => {
+      const dialog = event.currentTarget.closest('dialog');
+      dialog?.close();
+    });
+  });
+
+  dom.saveApiKeyButton?.addEventListener('click', () => {
+    state.apiKey = dom.apiKeyInput.value.trim();
+    saveApiKey(state.apiKey);
+    setFeedback(dom.apiKeyFeedback, state.apiKey ? 'API-Schlüssel gespeichert.' : 'Bitte einen gültigen Schlüssel eingeben.', state.apiKey ? 'success' : 'error');
+  });
+
+  dom.clearApiKeyButton?.addEventListener('click', () => {
+    dom.apiKeyInput.value = '';
+    state.apiKey = '';
+    saveApiKey('');
+    setFeedback(dom.apiKeyFeedback, 'API-Schlüssel entfernt. Öffentliche Limits gelten.', 'success');
+  });
+
+  dom.searchForm?.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    await handleSearchSubmit(new FormData(dom.searchForm));
+  });
+
+  dom.searchForm?.addEventListener('reset', () => {
+    setTimeout(() => {
+      state.searchResults = [];
+      renderCardResults([]);
+      setFeedback(dom.searchFeedback, 'Filter zurückgesetzt. Starte eine neue Suche.');
+    }, 0);
+  });
+
+  dom.resultsGrid?.addEventListener('click', handleCardActionClick);
+  dom.scannerResults?.addEventListener('click', handleCardActionClick);
+  dom.collectionGrid?.addEventListener('click', handleCollectionActionClick);
+  dom.wishlistGrid?.addEventListener('click', handleWishlistActionClick);
+  dom.deckDetail?.addEventListener('click', handleDeckDetailActionClick);
+
+  dom.collectionFilterForm?.addEventListener('change', () => {
+    renderCollection();
+    renderDashboard();
+  });
+
+  dom.createDeckButton?.addEventListener('click', () => openDeckEditor());
+  dom.deckList?.addEventListener('click', handleDeckListClick);
+
+  dom.cardEditorForm?.addEventListener('submit', handleCardEditorSubmit);
+  dom.deckPickerForm?.addEventListener('submit', handleDeckPickerSubmit);
+  dom.deckEditorForm?.addEventListener('submit', handleDeckEditorSubmit);
+
+  dom.updatePricesButton?.addEventListener('click', () => updateAllPrices());
+  dom.resetSettingsButton?.addEventListener('click', () => resetSettings());
+  dom.clearDataButton?.addEventListener('click', () => clearAllData());
+
+  dom.themeSelect?.addEventListener('change', () => updateSetting('theme', dom.themeSelect.value));
+  dom.currencySelect?.addEventListener('change', () => updateCurrency(dom.currencySelect.value));
+  dom.valuationModeSelect?.addEventListener('change', () => updateSetting('valuationMode', dom.valuationModeSelect.value));
+  dom.usdRateInput?.addEventListener('change', () => updateExchangeRate('USD', parseFloat(dom.usdRateInput.value)));
+  dom.gbpRateInput?.addEventListener('change', () => updateExchangeRate('GBP', parseFloat(dom.gbpRateInput.value)));
+  dom.priceIntervalInput?.addEventListener('change', () => updateSetting('priceIntervalDays', parseInt(dom.priceIntervalInput.value, 10) || DEFAULT_SETTINGS.priceIntervalDays));
+  dom.settingsNotes?.addEventListener('input', () => updateSetting('notes', dom.settingsNotes.value));
+
+  dom.exportCollectionCsvButton?.addEventListener('click', exportCollectionCsv);
+  dom.exportWishlistCsvButton?.addEventListener('click', exportWishlistCsv);
+  dom.exportDeckListButton?.addEventListener('click', exportDeckLists);
+  dom.exportJsonButton?.addEventListener('click', exportBackupJson);
+  dom.importJsonInput?.addEventListener('change', importBackupJson);
+
+  dom.startScannerButton?.addEventListener('click', startScanner);
+  dom.captureCardButton?.addEventListener('click', captureCard);
+  dom.stopScannerButton?.addEventListener('click', stopScanner);
+
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    if (state.settings.theme === 'system') {
+      applyTheme();
+    }
+  });
+}
+
+function renderAll() {
+  switchSection(state.activeSection);
+  renderCardResults(state.searchResults);
+  renderCollection();
+  renderWishlist();
+  renderDeckList();
+  renderDeckDetail();
+  renderDashboard();
+  renderDeckPickerOptions();
+}
+
+async function loadReferenceData() {
+  try {
+    setFeedback(dom.searchFeedback, 'Lade Sets und Filter …');
+    const [setsResponse, typesResponse, raritiesResponse, supertypesResponse] = await Promise.all([
+      apiFetch('/sets', { orderBy: '-releaseDate', pageSize: 250 }),
+      apiFetch('/types'),
+      apiFetch('/rarities'),
+      apiFetch('/supertypes')
+    ]);
+
+    state.sets = Array.isArray(setsResponse?.data) ? setsResponse.data : [];
+    state.series = Array.from(new Set(state.sets.map((set) => set.series).filter(Boolean))).sort((a, b) => a.localeCompare(b, 'de'));
+    state.typeOptions = typesResponse?.data ?? [];
+    state.rarityOptions = raritiesResponse?.data ?? [];
+    state.supertypeOptions = supertypesResponse?.data ?? [];
+
+    populateSetAndSeriesFilters();
+    populateTypeFilters();
+    populateRarityFilters();
+    populateSupertypeFilter();
+
+    renderSetList(state.sets.slice(0, FEATURED_SET_LIMIT));
+    setFeedback(dom.searchFeedback, 'Daten geladen. Starte eine Suche oder nutze den Scanner.');
+  } catch (error) {
+    console.error('Referenzdaten konnten nicht geladen werden', error);
+    setFeedback(dom.searchFeedback, `Fehler beim Laden der Referenzdaten: ${getErrorMessage(error)}`, 'error');
+  }
+}
+
+function populateSetAndSeriesFilters() {
+  if (dom.setFilter) {
+    dom.setFilter.innerHTML = '<option value="">Alle Sets</option>' + state.sets
+      .map((set) => `<option value="${set.id}">${escapeHtml(`${set.name} (${set.series})`)}</option>`)
+      .join('');
+  }
+  if (dom.collectionSetFilter) {
+    dom.collectionSetFilter.innerHTML = '<option value="">Alle</option>' + state.sets
+      .map((set) => `<option value="${set.id}">${escapeHtml(`${set.name} (${set.series})`)}</option>`)
+      .join('');
+  }
+  if (dom.seriesFilter) {
+    dom.seriesFilter.innerHTML = '<option value="">Alle Serien</option>' + state.series
+      .map((series) => `<option value="${escapeHtml(series)}">${escapeHtml(series)}</option>`)
+      .join('');
+  }
+  if (dom.collectionSeriesFilter) {
+    dom.collectionSeriesFilter.innerHTML = '<option value="">Alle</option>' + state.series
+      .map((series) => `<option value="${escapeHtml(series)}">${escapeHtml(series)}</option>`)
+      .join('');
+  }
+}
+
+function populateTypeFilters() {
+  const typeOptions = state.typeOptions
+    .map((type) => `<option value="${escapeHtml(type)}">${escapeHtml(type)}</option>`)
+    .join('');
+  if (dom.typeFilter) {
+    dom.typeFilter.innerHTML = '<option value="">Alle Typen</option>' + typeOptions;
+  }
+  if (dom.collectionTypeFilter) {
+    dom.collectionTypeFilter.innerHTML = '<option value="">Alle</option>' + typeOptions;
+  }
+}
+
+function populateRarityFilters() {
+  const rarityOptions = state.rarityOptions
+    .map((rarity) => `<option value="${escapeHtml(rarity)}">${escapeHtml(rarity)}</option>`)
+    .join('');
+  if (dom.rarityFilter) {
+    dom.rarityFilter.innerHTML = '<option value="">Alle Seltenheiten</option>' + rarityOptions;
+  }
+  if (dom.collectionRarityFilter) {
+    dom.collectionRarityFilter.innerHTML = '<option value="">Alle</option>' + rarityOptions;
+  }
+}
+
+function populateSupertypeFilter() {
+  if (!dom.supertypeFilter) {
+    return;
+  }
+  dom.supertypeFilter.innerHTML = '<option value="">Alle</option>' + state.supertypeOptions
+    .map((supertype) => `<option value="${escapeHtml(supertype)}">${escapeHtml(supertype)}</option>`)
+    .join('');
+}
+
+async function handleSearchSubmit(formData) {
+  if (state.isSearching) {
+    return;
+  }
+
+  const clauses = [];
+  const query = (formData.get('query') || '').toString().trim();
+  const setId = (formData.get('set') || '').toString();
+  const series = (formData.get('series') || '').toString();
+  const type = (formData.get('type') || '').toString();
+  const supertype = (formData.get('supertype') || '').toString();
+  const rarity = (formData.get('rarity') || '').toString();
+  const regulation = (formData.get('regulation') || '').toString();
+  const artist = (formData.get('artist') || '').toString().trim();
+  const year = (formData.get('year') || '').toString().trim();
+  const sort = (formData.get('sort') || 'name').toString();
+
+  if (query) {
+    const escaped = escapeQueryValue(query);
+    clauses.push(`(name:*\"${escaped}\"* OR subtypes:*\"${escaped}\"* OR abilities.text:*\"${escaped}\"*)`);
+  }
+  if (setId) {
+    clauses.push(`set.id:${setId}`);
+  }
+  if (series) {
+    clauses.push(`set.series:\"${escapeQueryValue(series)}\"`);
+  }
+  if (type) {
+    clauses.push(`types:${escapeQueryValue(type)}`);
+  }
+  if (supertype) {
+    clauses.push(`supertype:\"${escapeQueryValue(supertype)}\"`);
+  }
+  if (rarity) {
+    clauses.push(`rarity:\"${escapeQueryValue(rarity)}\"`);
+  }
+  if (regulation) {
+    clauses.push(`regulationMark:${escapeQueryValue(regulation)}`);
+  }
+  if (artist) {
+    clauses.push(`artist:*\"${escapeQueryValue(artist)}\"*`);
+  }
+  if (year) {
+    const numericYear = Number.parseInt(year, 10);
+    if (!Number.isNaN(numericYear)) {
+      const start = `${numericYear}-01-01`;
+      const end = `${numericYear}-12-31`;
+      clauses.push(`set.releaseDate:[${start} TO ${end}]`);
+    }
+  }
+
+  const params = new URLSearchParams({
+    pageSize: '48',
+    orderBy: sort
+  });
+
+  if (clauses.length) {
+    params.set('q', clauses.join(' AND '));
+  }
+
+  try {
+    state.isSearching = true;
+    setFeedback(dom.searchFeedback, 'Suche Karten …');
+    const response = await apiFetch('/cards', params);
+    const cards = response?.data ?? [];
+    state.searchResults = cards;
+    cards.forEach((card) => cardCache.set(card.id, card));
+    renderCardResults(cards);
+    setFeedback(dom.searchFeedback, cards.length ? `${cards.length} Karten gefunden.` : 'Keine passenden Karten gefunden.', cards.length ? 'success' : 'error');
+  } catch (error) {
+    console.error('Suche fehlgeschlagen', error);
+    setFeedback(dom.searchFeedback, `Suche fehlgeschlagen: ${getErrorMessage(error)}`, 'error');
+  } finally {
+    state.isSearching = false;
+  }
+}
+
+function renderCardResults(cards) {
+  if (!dom.resultsGrid) {
+    return;
+  }
+  dom.resultsGrid.innerHTML = '';
+  if (!cards.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.textContent = 'Noch keine Ergebnisse. Starte eine Suche oder nutze den Scanner.';
+    dom.resultsGrid.append(empty);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  cards.forEach((card) => {
+    fragment.append(createCardElement(card));
+  });
+  dom.resultsGrid.append(fragment);
+}
+
+function renderSetList(sets) {
+  if (!dom.setsGrid) {
+    return;
+  }
+  dom.setsGrid.innerHTML = '';
+  if (!sets.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.textContent = 'Keine Sets gefunden.';
+    dom.setsGrid.append(empty);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  sets.forEach((set) => {
+    const element = document.createElement('article');
+    element.className = 'set-card';
+
+    const img = document.createElement('img');
+    img.src = set.images?.symbol || set.images?.logo || '';
+    img.alt = `${set.name} Symbol`;
+    element.append(img);
+
+    const info = document.createElement('div');
+    const title = document.createElement('h3');
+    title.textContent = set.name;
+    info.append(title);
+
+    const details = document.createElement('p');
+    const date = formatDate(set.releaseDate);
+    const total = set.total ? `${set.total} Karten` : 'Unbekannte Anzahl';
+    details.textContent = `${set.series} · ${total}${date ? ` · ${date}` : ''}`;
+    info.append(details);
+
+    const action = document.createElement('button');
+    action.type = 'button';
+    action.className = 'secondary';
+    action.textContent = 'Im Suchfilter wählen';
+    action.addEventListener('click', () => {
+      if (dom.setFilter) {
+        dom.setFilter.value = set.id;
+      }
+      dom.searchForm?.dispatchEvent(new Event('submit'));
+    });
+    info.append(action);
+
+    element.append(info);
+    fragment.append(element);
+  });
+  dom.setsGrid.append(fragment);
+}
+
+function createCardElement(card) {
+  const template = dom.cardResultTemplate;
+  if (!template) {
+    throw new Error('Kartenvorlage fehlt');
+  }
+
+  const element = template.content.firstElementChild.cloneNode(true);
+  element.dataset.cardId = card.id;
+  const image = element.querySelector('.card-image');
+  image.src = card.images?.small || card.images?.large || '';
+  image.alt = `${card.name} (${card.set?.name ?? 'Pokémon TCG'})`;
+
+  element.querySelector('.card-title').textContent = card.name;
+  element.querySelector('.card-subtitle').textContent = card.set ? `${card.set.series} · ${card.set.name}` : 'Pokémon TCG Karte';
+
+  const metaList = element.querySelector('.card-meta');
+  metaList.innerHTML = '';
+  const metaParts = [];
+  if (card.number) metaParts.push(`Nr. ${card.number}`);
+  if (card.rarity) metaParts.push(card.rarity);
+  if (card.supertype) metaParts.push(card.supertype);
+  if (card.regulationMark) metaParts.push(`Reg. ${card.regulationMark}`);
+  if (card.artist) metaParts.push(card.artist);
+  metaParts.forEach((part) => {
+    const li = document.createElement('li');
+    li.textContent = part;
+    metaList.append(li);
+  });
+
+  const priceElement = element.querySelector('.card-price');
+  const priceInfo = extractMarketPrices(card);
+  if (priceInfo.aggregated.average !== null) {
+    priceElement.textContent = `Ø ${formatCurrency(priceInfo.aggregated[state.settings.valuationMode])}`;
+  } else {
+    priceElement.textContent = 'Keine Preisdaten verfügbar';
+  }
+
+  const badges = element.querySelector('.card-badges');
+  badges.innerHTML = '';
+  if (card.rarity) {
+    badges.append(createBadge(card.rarity));
+  }
+  if (card.types?.length) {
+    badges.append(createBadge(card.types.join(', ')));
+  }
+
+  const detailsLink = element.querySelector('.details-link');
+  if (detailsLink) {
+    detailsLink.href = createDetailsUrl(card.id);
+  }
+
+  return element;
+}
+
+function createBadge(text) {
+  const badge = document.createElement('span');
+  badge.className = 'badge';
+  badge.textContent = text;
+  return badge;
+}
+
+function handleCardActionClick(event) {
+  const actionButton = event.target.closest('button[data-action]');
+  if (!actionButton) {
+    return;
+  }
+  const cardElement = actionButton.closest('[data-card-id]');
+  if (!cardElement) {
+    return;
+  }
+  const cardId = cardElement.dataset.cardId;
+  const card = cardCache.get(cardId);
+  if (!card) {
+    setFeedback(dom.searchFeedback, 'Kartendaten konnten nicht geladen werden.', 'error');
+    return;
+  }
+
+  switch (actionButton.dataset.action) {
+    case 'add-to-collection':
+      openCardEditor(card, 'collection');
+      break;
+    case 'add-to-wishlist':
+      openCardEditor(card, 'wishlist');
+      break;
+    case 'add-to-deck':
+      openDeckPicker(card);
+      break;
+    default:
+      break;
+  }
+}
+
+function handleCollectionActionClick(event) {
+  const actionButton = event.target.closest('button[data-action]');
+  if (!actionButton) {
+    return;
+  }
+  const cardElement = actionButton.closest('[data-card-id]');
+  if (!cardElement) {
+    return;
+  }
+  const entryId = cardElement.dataset.cardId;
+  const entry = state.collection.find((item) => item.id === entryId);
+  if (!entry) {
+    return;
+  }
+
+  switch (actionButton.dataset.action) {
+    case 'edit-entry':
+      openCardEditor(entry, 'collection-edit');
+      break;
+    case 'update-price':
+      updateEntryPrice(entry);
+      break;
+    case 'add-to-deck':
+      getCardDetails(entry.id).then((card) => {
+        if (card) {
+          openDeckPicker(card);
+        }
+      });
+      break;
+    case 'remove-entry':
+      removeCollectionEntry(entry.id);
+      break;
+    default:
+      break;
+  }
+}
+
+function handleWishlistActionClick(event) {
+  const actionButton = event.target.closest('button[data-action]');
+  if (!actionButton) {
+    return;
+  }
+  const cardElement = actionButton.closest('[data-card-id]');
+  if (!cardElement) {
+    return;
+  }
+  const entryId = cardElement.dataset.cardId;
+  const entry = state.wishlist.find((item) => item.id === entryId);
+  if (!entry) {
+    return;
+  }
+
+  switch (actionButton.dataset.action) {
+    case 'move-to-collection':
+      getCardDetails(entry.id).then((card) => {
+        if (card) {
+          openCardEditor({ ...card, wishlistEntry: entry }, 'collection-from-wishlist');
+        }
+      });
+      break;
+    case 'edit-wishlist':
+      openCardEditor(entry, 'wishlist-edit');
+      break;
+    case 'remove-wishlist':
+      removeWishlistEntry(entry.id);
+      break;
+    default:
+      break;
+  }
+}
+
+function handleDeckListClick(event) {
+  const deckItem = event.target.closest('.deck-item');
+  if (!deckItem) {
+    return;
+  }
+  const deckId = deckItem.dataset.deckId;
+  const actionButton = event.target.closest('button[data-action]');
+  if (actionButton) {
+    if (actionButton.dataset.action === 'edit-deck') {
+      const deck = state.decks.find((item) => item.id === deckId);
+      if (deck) {
+        openDeckEditor(deck);
+      }
+      return;
+    }
+    if (actionButton.dataset.action === 'delete-deck') {
+      deleteDeck(deckId);
+      return;
+    }
+  }
+
+  selectDeck(deckId);
+}
+
+function handleDeckDetailActionClick(event) {
+  const button = event.target.closest('button[data-action]');
+  if (!button) {
+    return;
+  }
+  const deckId = state.selectedDeckId;
+  const deck = state.decks.find((item) => item.id === deckId);
+  if (!deck) {
+    return;
+  }
+
+  const cardId = button.dataset.cardId;
+  const category = button.dataset.category;
+  switch (button.dataset.action) {
+    case 'remove-deck-card':
+      updateDeckCardQuantity(deck, cardId, category, 0);
+      break;
+    case 'increase-deck-card':
+      updateDeckCardQuantity(deck, cardId, category, (getDeckCard(deck, cardId, category)?.quantity ?? 0) + 1);
+      break;
+    case 'decrease-deck-card':
+      updateDeckCardQuantity(deck, cardId, category, (getDeckCard(deck, cardId, category)?.quantity ?? 0) - 1);
+      break;
+    default:
+      break;
+  }
+}
+
+function handleCardEditorSubmit(event) {
+  event.preventDefault();
+  const mode = dom.cardEditorDialog.dataset.mode || 'collection';
+  const cardId = dom.cardEditorDialog.dataset.cardId;
+  const quantity = Math.max(1, parseInt(dom.cardQuantityInput.value, 10) || 1);
+  const condition = dom.cardConditionSelect.value;
+  const language = dom.cardLanguageSelect.value;
+  const edition = dom.cardEditionSelect.value;
+  const purchasePrice = parseFloat(dom.purchasePriceInput.value);
+  const purchaseDate = dom.purchaseDateInput.value || null;
+  const targetPrice = parseFloat(dom.targetPriceInput.value);
+  const priority = dom.prioritySelect.value || 'medium';
+  const notes = dom.cardNotesInput.value.trim();
+
+  const payload = {
+    cardId,
+    quantity,
+    condition,
+    language,
+    edition,
+    purchasePrice: Number.isFinite(purchasePrice) ? purchasePrice : null,
+    purchaseDate,
+    targetPrice: Number.isFinite(targetPrice) ? targetPrice : null,
+    priority,
+    notes
+  };
+
+  switch (mode) {
+    case 'collection':
+      addToCollection(cardId, payload);
+      break;
+    case 'collection-edit':
+      updateCollectionEntry(cardId, payload);
+      break;
+    case 'collection-from-wishlist':
+      moveWishlistEntryToCollection(cardId, payload);
+      break;
+    case 'wishlist':
+      addToWishlist(cardId, payload);
+      break;
+    case 'wishlist-edit':
+      updateWishlistEntry(cardId, payload);
+      break;
+    default:
+      break;
+  }
+
+  dom.cardEditorDialog.close('save');
+}
+
+function handleDeckPickerSubmit(event) {
+  event.preventDefault();
+  const deckId = dom.deckPickerSelect.value;
+  if (!deckId) {
+    setFeedback(dom.deckFeedback, 'Bitte zuerst ein Deck auswählen oder erstellen.', 'error');
+    return;
+  }
+  const deck = state.decks.find((item) => item.id === deckId);
+  if (!deck) {
+    setFeedback(dom.deckFeedback, 'Deck konnte nicht gefunden werden.', 'error');
+    return;
+  }
+
+  const cardId = dom.deckPickerCardId.value;
+  const quantity = Math.max(1, Math.min(4, parseInt(dom.deckPickerQuantity.value, 10) || 1));
+  const category = dom.deckPickerCategory.value || 'main';
+
+  getCardDetails(cardId).then((card) => {
+    if (card) {
+      addCardToDeck(deck, card, quantity, category);
+      dom.deckPickerDialog.close('save');
+    }
+  });
+}
+
+function handleDeckEditorSubmit(event) {
+  event.preventDefault();
+  const deckId = dom.deckEditorId.value;
+  const name = dom.deckNameInput.value.trim();
+  const format = dom.deckFormatSelect.value;
+  const notes = dom.deckNotesInput.value.trim();
+  if (!name) {
+    return;
+  }
+
+  if (deckId) {
+    const deck = state.decks.find((item) => item.id === deckId);
+    if (deck) {
+      deck.name = name;
+      deck.format = format;
+      deck.notes = notes;
+      deck.updatedAt = new Date().toISOString();
+      saveDecks();
+      renderDeckList();
+      renderDeckDetail();
+      setFeedback(dom.deckFeedback, 'Deck aktualisiert.', 'success');
+    }
+  } else {
+    const newDeck = {
+      id: crypto.randomUUID(),
+      name,
+      format,
+      notes,
+      cards: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+    state.decks.push(newDeck);
+    saveDecks();
+    renderDeckList();
+    selectDeck(newDeck.id);
+    setFeedback(dom.deckFeedback, 'Deck erstellt. Füge nun Karten hinzu.', 'success');
+  }
+
+  renderDeckPickerOptions();
+  dom.deckEditorDialog.close('save');
+}
+
+function switchSection(section) {
+  state.activeSection = section;
+  dom.views.forEach((view) => {
+    const isActive = view.dataset.section === section;
+    view.classList.toggle('is-active', isActive);
+    view.hidden = !isActive;
+  });
+  dom.navButtons.forEach((button) => {
+    button.classList.toggle('is-active', button.dataset.section === section);
+  });
+  if (section === 'deck') {
+    renderDeckDetail();
+  }
+}
+
+function openCardEditor(cardOrEntry, mode) {
+  if (!dom.cardEditorDialog) {
+    return;
+  }
+  const entry = state.collection.find((item) => item.id === cardOrEntry.id);
+  const wishlistEntry = state.wishlist.find((item) => item.id === cardOrEntry.id) || cardOrEntry.wishlistEntry;
+
+  const cardPromise = cardCache.has(cardOrEntry.id)
+    ? Promise.resolve(cardCache.get(cardOrEntry.id))
+    : getCardDetails(cardOrEntry.id);
+
+  cardPromise.then((cardData) => {
+    if (!cardData) {
+      setFeedback(dom.searchFeedback, 'Kartendaten konnten nicht geladen werden.', 'error');
+      return;
+    }
+    cardCache.set(cardData.id, cardData);
+
+    dom.cardEditorDialog.dataset.cardId = cardData.id;
+    dom.cardEditorDialog.dataset.mode = mode;
+    dom.cardEditorCardId.value = cardData.id;
+    dom.cardEditorMode.value = mode;
+
+    dom.cardEditorImage.src = cardData.images?.small || cardData.images?.large || '';
+    dom.cardEditorImage.alt = `${cardData.name} (${cardData.set?.name ?? 'Pokémon TCG'})`;
+    dom.cardEditorName.textContent = cardData.name;
+    dom.cardEditorInfo.textContent = cardData.set ? `${cardData.set.series} · ${cardData.set.name} · ${cardData.number ?? ''}` : '';
+
+    const priceInfo = extractMarketPrices(cardData);
+    dom.cardEditorPrices.textContent = priceInfo.aggregated.average !== null
+      ? `Ø ${formatCurrency(priceInfo.aggregated[state.settings.valuationMode])}`
+      : 'Keine Preisdaten verfügbar';
+
+    const defaults = {
+      quantity: 1,
+      condition: 'nearMint',
+      language: 'Deutsch',
+      edition: 'standard',
+      purchasePrice: '',
+      purchaseDate: '',
+      targetPrice: '',
+      priority: 'medium',
+      notes: ''
+    };
+
+    if (mode === 'collection-edit' && entry) {
+      defaults.quantity = entry.quantity ?? 1;
+      defaults.condition = entry.condition ?? 'nearMint';
+      defaults.language = entry.language ?? 'Deutsch';
+      defaults.edition = entry.edition ?? 'standard';
+      defaults.purchasePrice = entry.purchasePrice ?? '';
+      defaults.purchaseDate = entry.purchaseDate ?? '';
+      defaults.targetPrice = entry.targetPrice ?? '';
+      defaults.priority = entry.priority ?? 'medium';
+      defaults.notes = entry.notes ?? '';
+    } else if (mode === 'wishlist-edit' && wishlistEntry) {
+      defaults.quantity = wishlistEntry.quantity ?? 1;
+      defaults.targetPrice = wishlistEntry.targetPrice ?? '';
+      defaults.priority = wishlistEntry.priority ?? 'medium';
+      defaults.notes = wishlistEntry.notes ?? '';
+    } else if (mode === 'collection-from-wishlist' && wishlistEntry) {
+      defaults.quantity = wishlistEntry.quantity ?? 1;
+      defaults.targetPrice = wishlistEntry.targetPrice ?? '';
+      defaults.priority = wishlistEntry.priority ?? 'medium';
+      defaults.notes = wishlistEntry.notes ?? '';
+    }
+
+    dom.cardQuantityInput.value = defaults.quantity;
+    dom.cardConditionSelect.value = defaults.condition;
+    dom.cardLanguageSelect.value = defaults.language;
+    dom.cardEditionSelect.value = defaults.edition;
+    dom.purchasePriceInput.value = defaults.purchasePrice;
+    dom.purchaseDateInput.value = defaults.purchaseDate;
+    dom.targetPriceInput.value = defaults.targetPrice;
+    dom.prioritySelect.value = defaults.priority;
+    dom.cardNotesInput.value = defaults.notes;
+
+    configureCardEditorFields(mode);
+    dom.cardEditorTitle.textContent = getCardEditorTitle(mode);
+    dom.cardEditorDialog.showModal();
+  });
+}
+
+function configureCardEditorFields(mode) {
+  const showCollectionFields = mode.startsWith('collection');
+  const purchaseGroup = dom.purchasePriceInput.closest('label');
+  const dateGroup = dom.purchaseDateInput.closest('label');
+  const conditionGroup = dom.cardConditionSelect.closest('label');
+  const languageGroup = dom.cardLanguageSelect.closest('label');
+  const editionGroup = dom.cardEditionSelect.closest('label');
+
+  if (showCollectionFields) {
+    conditionGroup.hidden = false;
+    languageGroup.hidden = false;
+    editionGroup.hidden = false;
+    purchaseGroup.hidden = false;
+    dateGroup.hidden = false;
+  } else {
+    conditionGroup.hidden = true;
+    languageGroup.hidden = true;
+    editionGroup.hidden = true;
+    purchaseGroup.hidden = true;
+    dateGroup.hidden = true;
+  }
+
+  dom.prioritySelect.closest('label').hidden = !mode.includes('wishlist');
+}
+
+function getCardEditorTitle(mode) {
+  switch (mode) {
+    case 'collection-edit':
+      return 'Sammlungseintrag bearbeiten';
+    case 'collection-from-wishlist':
+      return 'Wunschliste in Sammlung übernehmen';
+    case 'wishlist':
+      return 'Zur Wunschliste hinzufügen';
+    case 'wishlist-edit':
+      return 'Wunschlisteneintrag bearbeiten';
+    default:
+      return 'Karte zur Sammlung hinzufügen';
+  }
+}
+
+function addToCollection(cardId, payload) {
+  getCardDetails(cardId).then((card) => {
+    if (!card) {
+      setFeedback(dom.collectionFeedback, 'Kartendaten konnten nicht geladen werden.', 'error');
+      return;
+    }
+    const existing = state.collection.find((entry) => entry.id === cardId);
+    if (existing) {
+      existing.quantity += payload.quantity;
+      existing.condition = payload.condition;
+      existing.language = payload.language;
+      existing.edition = payload.edition;
+      if (payload.purchasePrice !== null) {
+        addPurchaseHistory(existing, payload.purchasePrice, payload.quantity, payload.purchaseDate);
+        existing.purchasePrice = payload.purchasePrice;
+        existing.purchaseDate = payload.purchaseDate;
+      }
+      if (payload.targetPrice !== null) {
+        existing.targetPrice = payload.targetPrice;
+        existing.targetPriceCurrency = state.settings.currency;
+      }
+      if (payload.notes) {
+        existing.notes = payload.notes;
+      }
+      existing.priority = payload.priority ?? existing.priority;
+      existing.updatedAt = new Date().toISOString();
+      saveCollection();
+      renderCollection();
+      renderDashboard();
+      setFeedback(dom.collectionFeedback, `${existing.name} aktualisiert.`, 'success');
+      return;
+    }
+
+    const { aggregated, sources } = extractMarketPrices(card);
+    const entry = {
+      id: card.id,
+      name: card.name,
+      number: card.number ?? '',
+      setId: card.set?.id ?? '',
+      setName: card.set?.name ?? '',
+      setSeries: card.set?.series ?? '',
+      rarity: card.rarity ?? '',
+      supertype: card.supertype ?? '',
+      subtypes: card.subtypes ?? [],
+      types: card.types ?? [],
+      regulationMark: card.regulationMark ?? '',
+      artist: card.artist ?? '',
+      images: card.images ?? {},
+      url: createDetailsUrl(card.id),
+      quantity: payload.quantity,
+      condition: payload.condition,
+      language: payload.language,
+      edition: payload.edition,
+      purchasePrice: payload.purchasePrice ?? null,
+      purchaseDate: payload.purchaseDate,
+      purchaseHistory: payload.purchasePrice !== null ? [{
+        price: payload.purchasePrice,
+        quantity: payload.quantity,
+        date: payload.purchaseDate
+      }] : [],
+      targetPrice: payload.targetPrice ?? null,
+      targetPriceCurrency: payload.targetPrice !== null ? state.settings.currency : null,
+      priority: payload.priority ?? 'medium',
+      notes: payload.notes ?? '',
+      market: aggregated,
+      marketSources: sources,
+      priceHistory: aggregated.average !== null ? [{
+        timestamp: new Date().toISOString(),
+        ...aggregated
+      }] : [],
+      addedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+    state.collection.push(entry);
+    saveCollection();
+    renderCollection();
+    renderDashboard();
+    setFeedback(dom.collectionFeedback, `${entry.name} wurde zur Sammlung hinzugefügt.`, 'success');
+  });
+}
+
+function updateCollectionEntry(cardId, payload) {
+  const entry = state.collection.find((item) => item.id === cardId);
+  if (!entry) {
+    return;
+  }
+  entry.quantity = payload.quantity;
+  entry.condition = payload.condition;
+  entry.language = payload.language;
+  entry.edition = payload.edition;
+  if (payload.purchasePrice !== null) {
+    entry.purchasePrice = payload.purchasePrice;
+    entry.purchaseDate = payload.purchaseDate;
+    addPurchaseHistory(entry, payload.purchasePrice, payload.quantity, payload.purchaseDate);
+  }
+  if (payload.targetPrice !== null) {
+    entry.targetPrice = payload.targetPrice;
+    entry.targetPriceCurrency = state.settings.currency;
+  } else {
+    entry.targetPrice = null;
+    entry.targetPriceCurrency = null;
+  }
+  entry.priority = payload.priority ?? entry.priority;
+  entry.notes = payload.notes;
+  entry.updatedAt = new Date().toISOString();
+  saveCollection();
+  renderCollection();
+  renderDashboard();
+  setFeedback(dom.collectionFeedback, 'Sammlungseintrag gespeichert.', 'success');
+}
+
+function addPurchaseHistory(entry, price, quantity, date) {
+  entry.purchaseHistory = entry.purchaseHistory || [];
+  entry.purchaseHistory.push({
+    price,
+    quantity,
+    date: date || null
+  });
+}
+
+function removeCollectionEntry(cardId) {
+  if (!confirm('Soll dieser Eintrag wirklich entfernt werden?')) {
+    return;
+  }
+  const index = state.collection.findIndex((entry) => entry.id === cardId);
+  if (index === -1) {
+    return;
+  }
+  const [removed] = state.collection.splice(index, 1);
+  saveCollection();
+  renderCollection();
+  renderDashboard();
+  setFeedback(dom.collectionFeedback, `${removed.name} wurde entfernt.`, 'success');
+}
+
+function addToWishlist(cardId, payload) {
+  getCardDetails(cardId).then((card) => {
+    if (!card) {
+      setFeedback(dom.wishlistFeedback, 'Kartendaten konnten nicht geladen werden.', 'error');
+      return;
+    }
+    const existing = state.wishlist.find((entry) => entry.id === cardId);
+    const { aggregated, sources } = extractMarketPrices(card);
+
+    if (existing) {
+      existing.quantity = payload.quantity;
+      existing.targetPrice = payload.targetPrice ?? existing.targetPrice;
+      existing.targetPriceCurrency = payload.targetPrice !== null ? state.settings.currency : existing.targetPriceCurrency;
+      existing.priority = payload.priority ?? existing.priority;
+      existing.notes = payload.notes;
+      existing.market = aggregated;
+      existing.marketSources = sources;
+      existing.updatedAt = new Date().toISOString();
+      saveWishlist();
+      renderWishlist();
+      renderDashboard();
+      setFeedback(dom.wishlistFeedback, `${existing.name} aktualisiert.`, 'success');
+      return;
+    }
+
+    const entry = {
+      id: card.id,
+      name: card.name,
+      number: card.number ?? '',
+      setId: card.set?.id ?? '',
+      setName: card.set?.name ?? '',
+      setSeries: card.set?.series ?? '',
+      rarity: card.rarity ?? '',
+      supertype: card.supertype ?? '',
+      subtypes: card.subtypes ?? [],
+      types: card.types ?? [],
+      regulationMark: card.regulationMark ?? '',
+      images: card.images ?? {},
+      url: createDetailsUrl(card.id),
+      quantity: payload.quantity,
+      targetPrice: payload.targetPrice ?? null,
+      targetPriceCurrency: payload.targetPrice !== null ? state.settings.currency : null,
+      priority: payload.priority ?? 'medium',
+      notes: payload.notes ?? '',
+      market: aggregated,
+      marketSources: sources,
+      priceHistory: aggregated.average !== null ? [{
+        timestamp: new Date().toISOString(),
+        ...aggregated
+      }] : [],
+      addedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+    state.wishlist.push(entry);
+    saveWishlist();
+    renderWishlist();
+    renderDashboard();
+    setFeedback(dom.wishlistFeedback, `${entry.name} zur Wunschliste hinzugefügt.`, 'success');
+  });
+}
+
+function updateWishlistEntry(cardId, payload) {
+  const entry = state.wishlist.find((item) => item.id === cardId);
+  if (!entry) {
+    return;
+  }
+  entry.quantity = payload.quantity;
+  entry.targetPrice = payload.targetPrice ?? entry.targetPrice;
+  entry.targetPriceCurrency = payload.targetPrice !== null ? state.settings.currency : entry.targetPriceCurrency;
+  entry.priority = payload.priority ?? entry.priority;
+  entry.notes = payload.notes ?? entry.notes;
+  entry.updatedAt = new Date().toISOString();
+  saveWishlist();
+  renderWishlist();
+  renderDashboard();
+  setFeedback(dom.wishlistFeedback, 'Wunschlisteneintrag gespeichert.', 'success');
+}
+
+function removeWishlistEntry(cardId) {
+  const index = state.wishlist.findIndex((entry) => entry.id === cardId);
+  if (index === -1) {
+    return;
+  }
+  const [removed] = state.wishlist.splice(index, 1);
+  saveWishlist();
+  renderWishlist();
+  renderDashboard();
+  setFeedback(dom.wishlistFeedback, `${removed.name} von der Wunschliste entfernt.`, 'success');
+}
+
+function moveWishlistEntryToCollection(cardId, payload) {
+  addToCollection(cardId, payload);
+  removeWishlistEntry(cardId);
+}
+
+function renderCollection() {
+  if (!dom.collectionGrid) {
+    return;
+  }
+  const filters = {
+    setId: dom.collectionSetFilter?.value || '',
+    series: dom.collectionSeriesFilter?.value || '',
+    rarity: dom.collectionRarityFilter?.value || '',
+    type: dom.collectionTypeFilter?.value || '',
+    condition: dom.collectionConditionFilter?.value || '',
+    language: dom.collectionLanguageFilter?.value || '',
+    sort: dom.collectionSort?.value || 'name'
+  };
+
+  let entries = [...state.collection];
+  if (filters.setId) {
+    entries = entries.filter((entry) => entry.setId === filters.setId);
+  }
+  if (filters.series) {
+    entries = entries.filter((entry) => entry.setSeries === filters.series);
+  }
+  if (filters.rarity) {
+    entries = entries.filter((entry) => entry.rarity === filters.rarity);
+  }
+  if (filters.type) {
+    entries = entries.filter((entry) => entry.types?.includes(filters.type));
+  }
+  if (filters.condition) {
+    entries = entries.filter((entry) => entry.condition === filters.condition);
+  }
+  if (filters.language) {
+    entries = entries.filter((entry) => entry.language === filters.language);
+  }
+
+  switch (filters.sort) {
+    case '-value':
+      entries.sort((a, b) => (getEntryValue(b) - getEntryValue(a)) || a.name.localeCompare(b.name, 'de'));
+      break;
+    case 'value':
+      entries.sort((a, b) => (getEntryValue(a) - getEntryValue(b)) || a.name.localeCompare(b.name, 'de'));
+      break;
+    case 'set':
+      entries.sort((a, b) => {
+        const setCompare = a.setName.localeCompare(b.setName, 'de');
+        if (setCompare !== 0) {
+          return setCompare;
+        }
+        const numberA = Number.parseInt(a.number, 10) || 0;
+        const numberB = Number.parseInt(b.number, 10) || 0;
+        return numberA - numberB;
+      });
+      break;
+    case 'added':
+      entries.sort((a, b) => new Date(b.updatedAt || b.addedAt || 0) - new Date(a.updatedAt || a.addedAt || 0));
+      break;
+    default:
+      entries.sort((a, b) => a.name.localeCompare(b.name, 'de'));
+      break;
+  }
+
+  dom.collectionGrid.innerHTML = '';
+  if (!entries.length) {
+    dom.collectionEmptyState.style.display = 'block';
+  } else {
+    dom.collectionEmptyState.style.display = 'none';
+    const fragment = document.createDocumentFragment();
+    entries.forEach((entry) => {
+      fragment.append(createCollectionCard(entry));
+    });
+    dom.collectionGrid.append(fragment);
+  }
+
+  renderCollectionSummary(entries);
+}
+
+function createCollectionCard(entry) {
+  const template = dom.collectionItemTemplate;
+  if (!template) {
+    throw new Error('Sammlungsvorlage fehlt');
+  }
+  const element = template.content.firstElementChild.cloneNode(true);
+  element.dataset.cardId = entry.id;
+
+  const image = element.querySelector('.card-image');
+  image.src = entry.images?.small || entry.images?.large || '';
+  image.alt = `${entry.name} (${entry.setName || 'Pokémon TCG'})`;
+
+  element.querySelector('.card-title').textContent = entry.name;
+  element.querySelector('.card-subtitle').textContent = [entry.setSeries, entry.setName].filter(Boolean).join(' · ');
+
+  const metaList = element.querySelector('.card-meta');
+  metaList.innerHTML = '';
+  const metaParts = [];
+  if (entry.number) metaParts.push(`Nr. ${entry.number}`);
+  if (entry.rarity) metaParts.push(entry.rarity);
+  if (entry.types?.length) metaParts.push(entry.types.join(', '));
+  metaParts.push(`Menge: ${entry.quantity}`);
+  if (entry.condition) metaParts.push(`Zustand: ${getConditionLabel(entry.condition)}`);
+  if (entry.language) metaParts.push(entry.language);
+  metaParts.forEach((part) => {
+    const li = document.createElement('li');
+    li.textContent = part;
+    metaList.append(li);
+  });
+
+  const priceElement = element.querySelector('.card-price');
+  const value = getEntryValue(entry);
+  if (value) {
+    priceElement.textContent = `${formatCurrency(value)} (${getValuationLabel()})`;
+  } else {
+    priceElement.textContent = 'Kein Marktwert verfügbar';
+  }
+
+  const notesElement = element.querySelector('.card-notes');
+  const notes = [];
+  if (entry.purchasePrice !== null) {
+    const date = entry.purchaseDate ? ` am ${formatDate(entry.purchaseDate)}` : '';
+    notes.push(`Kaufpreis: ${formatCurrency(entry.purchasePrice)}${date}`);
+  }
+  if (entry.notes) {
+    notes.push(entry.notes);
+  }
+  notesElement.textContent = notes.join(' · ');
+
+  const badges = element.querySelector('.card-badges');
+  badges.innerHTML = '';
+  if (entry.targetPrice !== null) {
+    badges.append(createBadge(`Alarm: ${formatCurrency(entry.targetPrice)}`));
+  }
+  if (entry.priority) {
+    badges.append(createBadge(PRIORITY_LABELS[entry.priority] ?? entry.priority));
+  }
+
+  return element;
+}
+
+function renderCollectionSummary(entries) {
+  if (!dom.collectionSummary) {
+    return;
+  }
+  const totalCards = entries.reduce((sum, entry) => sum + entry.quantity, 0);
+  const uniqueCards = entries.length;
+  const totalValue = entries.reduce((sum, entry) => sum + getEntryValue(entry), 0);
+  const averageValue = uniqueCards ? totalValue / uniqueCards : 0;
+
+  dom.collectionSummary.innerHTML = '';
+  const data = [
+    { label: 'Gesamtwert', value: formatCurrency(totalValue) },
+    { label: 'Einträge', value: uniqueCards.toString() },
+    { label: 'Karten gesamt', value: totalCards.toString() },
+    { label: 'Ø pro Karte', value: formatCurrency(averageValue) }
+  ];
+  data.forEach((item) => {
+    const summary = document.createElement('div');
+    summary.className = 'summary-card';
+    const value = document.createElement('strong');
+    value.textContent = item.value;
+    const label = document.createElement('span');
+    label.textContent = item.label;
+    summary.append(value, label);
+    dom.collectionSummary.append(summary);
+  });
+}
+
+function renderWishlist() {
+  if (!dom.wishlistGrid) {
+    return;
+  }
+  dom.wishlistGrid.innerHTML = '';
+  if (!state.wishlist.length) {
+    dom.wishlistEmptyState.style.display = 'block';
+    return;
+  }
+  dom.wishlistEmptyState.style.display = 'none';
+  const fragment = document.createDocumentFragment();
+  const sorted = [...state.wishlist].sort((a, b) => {
+    const priorityOrder = { high: 0, medium: 1, low: 2 };
+    const priorityCompare = (priorityOrder[a.priority] ?? 1) - (priorityOrder[b.priority] ?? 1);
+    if (priorityCompare !== 0) {
+      return priorityCompare;
+    }
+    return a.name.localeCompare(b.name, 'de');
+  });
+  sorted.forEach((entry) => {
+    fragment.append(createWishlistCard(entry));
+  });
+  dom.wishlistGrid.append(fragment);
+}
+
+function createWishlistCard(entry) {
+  const template = dom.wishlistItemTemplate;
+  if (!template) {
+    throw new Error('Wunschlistenvorlage fehlt');
+  }
+  const element = template.content.firstElementChild.cloneNode(true);
+  element.dataset.cardId = entry.id;
+
+  const image = element.querySelector('.card-image');
+  image.src = entry.images?.small || entry.images?.large || '';
+  image.alt = `${entry.name} (${entry.setName || 'Pokémon TCG'})`;
+
+  element.querySelector('.card-title').textContent = entry.name;
+  element.querySelector('.card-subtitle').textContent = [entry.setSeries, entry.setName].filter(Boolean).join(' · ');
+
+  const metaList = element.querySelector('.card-meta');
+  metaList.innerHTML = '';
+  const metaParts = [];
+  if (entry.number) metaParts.push(`Nr. ${entry.number}`);
+  if (entry.rarity) metaParts.push(entry.rarity);
+  if (entry.quantity) metaParts.push(`Anzahl: ${entry.quantity}`);
+  metaParts.push(PRIORITY_LABELS[entry.priority] ?? entry.priority);
+  metaParts.forEach((part) => {
+    const li = document.createElement('li');
+    li.textContent = part;
+    metaList.append(li);
+  });
+
+  const priceElement = element.querySelector('.card-price');
+  const value = entry.market?.[state.settings.valuationMode];
+  if (value !== null && value !== undefined) {
+    priceElement.textContent = `${getValuationLabel()}: ${formatCurrency(value)}`;
+  } else {
+    priceElement.textContent = 'Kein Marktwert verfügbar';
+  }
+
+  const targetElement = element.querySelector('.card-target');
+  if (entry.targetPrice !== null) {
+    targetElement.textContent = `Zielpreis: ${formatCurrency(entry.targetPrice)} (${entry.targetPriceCurrency ?? state.settings.currency})`;
+  } else {
+    targetElement.textContent = 'Kein Zielpreis definiert';
+  }
+
+  const badges = element.querySelector('.card-badges');
+  badges.innerHTML = '';
+  if (entry.market?.timestamp) {
+    badges.append(createBadge(formatRelativeTime(entry.market.timestamp)));
+  }
+
+  return element;
+}
+
+function renderDeckList() {
+  if (!dom.deckList) {
+    return;
+  }
+  dom.deckList.innerHTML = '';
+  if (!state.decks.length) {
+    const empty = document.createElement('p');
+    empty.className = 'empty-state';
+    empty.textContent = 'Noch keine Decks angelegt.';
+    dom.deckList.append(empty);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  state.decks.forEach((deck) => {
+    fragment.append(createDeckListItem(deck));
+  });
+  dom.deckList.append(fragment);
+}
+
+function createDeckListItem(deck) {
+  const template = dom.deckListItemTemplate;
+  if (!template) {
+    throw new Error('Decklisten-Vorlage fehlt');
+  }
+  const element = template.content.firstElementChild.cloneNode(true);
+  element.dataset.deckId = deck.id;
+  element.classList.toggle('is-active', deck.id === state.selectedDeckId);
+
+  const button = element.querySelector('.deck-select-button');
+  button.textContent = deck.name;
+
+  const meta = element.querySelector('.deck-meta');
+  const mainCount = deck.cards.filter((card) => card.category === 'main').reduce((sum, card) => sum + card.quantity, 0);
+  meta.textContent = `${CATEGORY_LABELS.main}: ${mainCount} · Format: ${deck.format}`;
+
+  return element;
+}
+
+function selectDeck(deckId) {
+  state.selectedDeckId = deckId;
+  renderDeckList();
+  renderDeckDetail();
+}
+
+function renderDeckDetail() {
+  if (!dom.deckDetail) {
+    return;
+  }
+  const deck = state.decks.find((item) => item.id === state.selectedDeckId);
+  dom.deckDetail.innerHTML = '';
+  if (!deck) {
+    const empty = document.createElement('p');
+    empty.className = 'empty-state';
+    empty.textContent = 'Wähle ein Deck oder lege ein neues an.';
+    dom.deckDetail.append(empty);
+    return;
+  }
+
+  const header = document.createElement('div');
+  header.className = 'deck-summary';
+  const mainCount = deck.cards.filter((card) => card.category === 'main').reduce((sum, item) => sum + item.quantity, 0);
+  const sideCount = deck.cards.filter((card) => card.category === 'side').reduce((sum, item) => sum + item.quantity, 0);
+  const extraCount = deck.cards.filter((card) => card.category === 'extra').reduce((sum, item) => sum + item.quantity, 0);
+
+  header.append(createSummaryCard('Hauptdeck', `${mainCount}/60`));
+  header.append(createSummaryCard('Sideboard', `${sideCount}/15`));
+  header.append(createSummaryCard('Extra', `${extraCount}`));
+
+  const warnings = validateDeck(deck);
+  if (warnings.length) {
+    const warningList = document.createElement('ul');
+    warningList.className = 'alerts-list';
+    warnings.forEach((warning) => {
+      const li = document.createElement('li');
+      li.className = 'alert';
+      const title = document.createElement('strong');
+      title.textContent = 'Regelhinweis';
+      const message = document.createElement('p');
+      message.textContent = warning;
+      li.append(title, message);
+      warningList.append(li);
+    });
+    dom.deckDetail.append(warningList);
+  }
+
+  dom.deckDetail.append(header);
+  dom.deckDetail.append(createDeckTable(deck));
+
+  if (deck.notes) {
+    const notes = document.createElement('p');
+    notes.textContent = `Notizen: ${deck.notes}`;
+    dom.deckDetail.append(notes);
+  }
+}
+
+function createSummaryCard(label, value) {
+  const element = document.createElement('div');
+  element.className = 'summary-card';
+  const strong = document.createElement('strong');
+  strong.textContent = value;
+  const span = document.createElement('span');
+  span.textContent = label;
+  element.append(strong, span);
+  return element;
+}
+
+function createDeckTable(deck) {
+  const table = document.createElement('table');
+  const tbody = document.createElement('tbody');
+
+  const groups = ['main', 'side', 'extra'];
+  groups.forEach((category) => {
+    const cards = deck.cards.filter((card) => card.category === category);
+    if (!cards.length) {
+      return;
+    }
+    const headerRow = document.createElement('tr');
+    const headerCell = document.createElement('th');
+    headerCell.colSpan = 4;
+    headerCell.textContent = CATEGORY_LABELS[category];
+    headerRow.append(headerCell);
+    tbody.append(headerRow);
+
+    cards.sort((a, b) => a.name.localeCompare(b.name, 'de')).forEach((card) => {
+      const row = document.createElement('tr');
+      const quantityCell = document.createElement('td');
+      quantityCell.textContent = card.quantity.toString();
+      const nameCell = document.createElement('td');
+      nameCell.textContent = card.name;
+      const infoCell = document.createElement('td');
+      infoCell.textContent = `${card.setName ?? ''} ${card.number ?? ''}`.trim();
+      const actionsCell = document.createElement('td');
+      actionsCell.append(
+        createDeckActionButton('−', 'decrease-deck-card', card.cardId, category),
+        createDeckActionButton('+', 'increase-deck-card', card.cardId, category),
+        createDeckActionButton('Entfernen', 'remove-deck-card', card.cardId, category)
+      );
+      row.append(quantityCell, nameCell, infoCell, actionsCell);
+      tbody.append(row);
+    });
+  });
+
+  table.append(tbody);
+  return table;
+}
+
+function createDeckActionButton(label, action, cardId, category) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'secondary';
+  button.textContent = label;
+  button.dataset.action = action;
+  button.dataset.cardId = cardId;
+  button.dataset.category = category;
+  return button;
+}
+
+function renderDeckPickerOptions() {
+  if (!dom.deckPickerSelect) {
+    return;
+  }
+  dom.deckPickerSelect.innerHTML = '';
+  if (!state.decks.length) {
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = 'Kein Deck vorhanden';
+    dom.deckPickerSelect.append(option);
+    return;
+  }
+  state.decks.forEach((deck) => {
+    const option = document.createElement('option');
+    option.value = deck.id;
+    option.textContent = deck.name;
+    dom.deckPickerSelect.append(option);
+  });
+}
+
+function openDeckPicker(card) {
+  if (!state.decks.length) {
+    setFeedback(dom.deckFeedback, 'Bitte lege zuerst ein Deck an.', 'error');
+    return;
+  }
+  dom.deckPickerCardId.value = card.id;
+  dom.deckPickerCardInfo.textContent = `${card.name} (${card.set?.name ?? 'Pokémon TCG'})`;
+  dom.deckPickerQuantity.value = '1';
+  dom.deckPickerDialog.showModal();
+}
+
+function openDeckEditor(deck) {
+  dom.deckEditorId.value = deck?.id ?? '';
+  dom.deckEditorTitle.textContent = deck ? 'Deck bearbeiten' : 'Deck anlegen';
+  dom.deckNameInput.value = deck?.name ?? '';
+  dom.deckFormatSelect.value = deck?.format ?? 'standard';
+  dom.deckNotesInput.value = deck?.notes ?? '';
+  dom.deckEditorDialog.showModal();
+}
+
+function addCardToDeck(deck, card, quantity, category) {
+  const existing = getDeckCard(deck, card.id, category);
+  const maxCopies = card.supertype === 'Energy' && card.subtypes?.includes('Basic') ? 99 : 4;
+  if (existing) {
+    existing.quantity = Math.min(maxCopies, existing.quantity + quantity);
+  } else {
+    deck.cards.push({
+      cardId: card.id,
+      name: card.name,
+      quantity: Math.min(maxCopies, quantity),
+      category,
+      setName: card.set?.name ?? '',
+      number: card.number ?? '',
+      supertype: card.supertype ?? '',
+      subtypes: card.subtypes ?? []
+    });
+  }
+  deck.updatedAt = new Date().toISOString();
+  saveDecks();
+  renderDeckDetail();
+  renderDeckList();
+  renderDeckPickerOptions();
+  setFeedback(dom.deckFeedback, `${card.name} wurde dem Deck ${deck.name} hinzugefügt.`, 'success');
+}
+
+function getDeckCard(deck, cardId, category) {
+  return deck.cards.find((item) => item.cardId === cardId && item.category === category);
+}
+
+function updateDeckCardQuantity(deck, cardId, category, quantity) {
+  const card = getDeckCard(deck, cardId, category);
+  if (!card) {
+    return;
+  }
+  if (quantity <= 0) {
+    deck.cards = deck.cards.filter((item) => !(item.cardId === cardId && item.category === category));
+  } else {
+    const maxCopies = card.supertype === 'Energy' && card.subtypes?.includes('Basic') ? 99 : 4;
+    card.quantity = Math.min(maxCopies, quantity);
+  }
+  deck.updatedAt = new Date().toISOString();
+  saveDecks();
+  renderDeckDetail();
+  renderDeckList();
+}
+
+function deleteDeck(deckId) {
+  if (!confirm('Soll dieses Deck wirklich gelöscht werden?')) {
+    return;
+  }
+  const index = state.decks.findIndex((deck) => deck.id === deckId);
+  if (index === -1) {
+    return;
+  }
+  state.decks.splice(index, 1);
+  if (state.selectedDeckId === deckId) {
+    state.selectedDeckId = state.decks[0]?.id ?? null;
+  }
+  saveDecks();
+  renderDeckList();
+  renderDeckDetail();
+  renderDeckPickerOptions();
+  setFeedback(dom.deckFeedback, 'Deck gelöscht.', 'success');
+}
+
+function validateDeck(deck) {
+  const warnings = [];
+  const mainCount = deck.cards.filter((card) => card.category === 'main').reduce((sum, item) => sum + item.quantity, 0);
+  if (mainCount !== 60) {
+    warnings.push('Ein Standarddeck muss exakt 60 Karten im Hauptdeck enthalten.');
+  }
+  deck.cards.filter((card) => card.category === 'main').forEach((card) => {
+    const maxCopies = card.supertype === 'Energy' && card.subtypes?.includes('Basic') ? Infinity : 4;
+    if (card.quantity > maxCopies) {
+      warnings.push(`${card.name} überschreitet die erlaubte Anzahl von ${maxCopies === Infinity ? 'unendlich' : maxCopies} Kopien.`);
+    }
+  });
+  return warnings;
+}
+
+function renderDashboard() {
+  renderDashboardOverview();
+  renderSetProgress();
+  renderDistributions();
+  renderPriceAlerts();
+}
+
+function renderDashboardOverview() {
+  if (!dom.dashboardOverview) {
+    return;
+  }
+  const totalValue = state.collection.reduce((sum, entry) => sum + getEntryValue(entry), 0);
+  const ownedSets = new Set(state.collection.map((entry) => entry.setId).filter(Boolean)).size;
+  const wishlistValue = state.wishlist.reduce((sum, entry) => sum + (entry.market?.[state.settings.valuationMode] ?? 0), 0);
+  const priceUpdateInfo = state.settings.lastPriceUpdate
+    ? formatRelativeTime(state.settings.lastPriceUpdate)
+    : 'Noch nicht aktualisiert';
+
+  const cardsOwned = state.collection.reduce((sum, entry) => sum + entry.quantity, 0);
+  const cardsWishlist = state.wishlist.reduce((sum, entry) => sum + entry.quantity, 0);
+
+  dom.dashboardOverview.innerHTML = '';
+  const data = [
+    { label: 'Wert der Sammlung', value: formatCurrency(totalValue) },
+    { label: 'Sets vertreten', value: ownedSets.toString() },
+    { label: 'Wert Wunschliste', value: formatCurrency(wishlistValue) },
+    { label: 'Letztes Preisupdate', value: priceUpdateInfo },
+    { label: 'Karten gesamt', value: cardsOwned.toString() },
+    { label: 'Wunschkarten', value: cardsWishlist.toString() }
+  ];
+  data.forEach((item) => {
+    const summary = document.createElement('div');
+    summary.className = 'summary-card';
+    const value = document.createElement('strong');
+    value.textContent = item.value;
+    const label = document.createElement('span');
+    label.textContent = item.label;
+    summary.append(value, label);
+    dom.dashboardOverview.append(summary);
+  });
+}
+
+function renderSetProgress() {
+  if (!dom.setProgressList) {
+    return;
+  }
+  dom.setProgressList.innerHTML = '';
+  if (!state.collection.length || !state.sets.length) {
+    const empty = document.createElement('p');
+    empty.className = 'empty-state';
+    empty.textContent = 'Füge Karten hinzu, um den Set-Fortschritt zu sehen.';
+    dom.setProgressList.append(empty);
+    return;
+  }
+
+  const grouped = new Map();
+  state.collection.forEach((entry) => {
+    if (!entry.setId) {
+      return;
+    }
+    const existing = grouped.get(entry.setId) || { count: 0, set: state.sets.find((set) => set.id === entry.setId) };
+    existing.count += entry.quantity;
+    grouped.set(entry.setId, existing);
+  });
+
+  const items = Array.from(grouped.values())
+    .filter((item) => item.set)
+    .sort((a, b) => new Date(b.set.releaseDate || 0) - new Date(a.set.releaseDate || 0))
+    .slice(0, 10);
+
+  items.forEach((item) => {
+    const progressItem = document.createElement('div');
+    progressItem.className = 'progress-item';
+    const label = document.createElement('span');
+    label.textContent = `${item.set.name} (${item.count}/${item.set.total ?? '?'})`;
+    const bar = document.createElement('div');
+    bar.className = 'progress-bar';
+    const inner = document.createElement('span');
+    const percent = item.set.total ? Math.min(100, Math.round((item.count / item.set.total) * 100)) : 0;
+    inner.style.width = `${percent}%`;
+    bar.append(inner);
+    progressItem.append(label, bar);
+    dom.setProgressList.append(progressItem);
+  });
+}
+
+function renderDistributions() {
+  renderDistribution(dom.rarityDistribution, computeDistribution(state.collection, (entry) => entry.rarity || 'Unbekannt'), 'Raritäten');
+  renderDistribution(dom.conditionDistribution, computeDistribution(state.collection, (entry) => getConditionLabel(entry.condition || 'unbekannt')), 'Zustände');
+}
+
+function computeDistribution(entries, selector) {
+  const distribution = new Map();
+  entries.forEach((entry) => {
+    const key = selector(entry);
+    const current = distribution.get(key) || 0;
+    distribution.set(key, current + entry.quantity);
+  });
+  const total = Array.from(distribution.values()).reduce((sum, value) => sum + value, 0);
+  return Array.from(distribution.entries()).map(([label, count]) => ({
+    label,
+    count,
+    percent: total ? Math.round((count / total) * 100) : 0
+  }));
+}
+
+function renderDistribution(container, data, fallbackLabel) {
+  if (!container) {
+    return;
+  }
+  container.innerHTML = '';
+  if (!data.length) {
+    const empty = document.createElement('p');
+    empty.className = 'empty-state';
+    empty.textContent = `Noch keine Daten für ${fallbackLabel}.`;
+    container.append(empty);
+    return;
+  }
+  data
+    .sort((a, b) => b.count - a.count)
+    .forEach((item) => {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'progress-item';
+      const label = document.createElement('span');
+      label.textContent = `${item.label} – ${item.count} (${item.percent}%)`;
+      const bar = document.createElement('div');
+      bar.className = 'progress-bar';
+      const inner = document.createElement('span');
+      inner.style.width = `${item.percent}%`;
+      bar.append(inner);
+      wrapper.append(label, bar);
+      container.append(wrapper);
+    });
+}
+
+function renderPriceAlerts() {
+  if (!dom.alertsList) {
+    return;
+  }
+  dom.alertsList.innerHTML = '';
+  const alerts = [];
+
+  state.collection.forEach((entry) => {
+    if (entry.targetPrice !== null) {
+      const currentValue = getEntryValue(entry);
+      if (currentValue && currentValue <= entry.targetPrice) {
+        alerts.push({
+          id: entry.id,
+          name: entry.name,
+          message: `${entry.name} liegt mit ${formatCurrency(currentValue)} unter deinem Zielpreis von ${formatCurrency(entry.targetPrice)}.`
+        });
+      }
+    }
+  });
+
+  state.wishlist.forEach((entry) => {
+    if (entry.targetPrice !== null) {
+      const marketValue = entry.market?.[state.settings.valuationMode];
+      if (marketValue && marketValue <= entry.targetPrice) {
+        alerts.push({
+          id: entry.id,
+          name: entry.name,
+          message: `${entry.name} ist aktuell für ${formatCurrency(marketValue)} verfügbar (Zielpreis ${formatCurrency(entry.targetPrice)}).`
+        });
+      }
+    }
+  });
+
+  if (!alerts.length) {
+    const empty = document.createElement('p');
+    empty.className = 'empty-state';
+    empty.textContent = 'Noch keine Preisalarme erreicht.';
+    dom.alertsList.append(empty);
+    return;
+  }
+
+  alerts.forEach((alert) => {
+    dom.alertsList.append(createAlertElement(alert));
+  });
+}
+
+function createAlertElement(alert) {
+  const template = dom.alertTemplate;
+  if (!template) {
+    const fallback = document.createElement('div');
+    fallback.className = 'alert';
+    const title = document.createElement('strong');
+    title.textContent = alert.name;
+    const message = document.createElement('p');
+    message.textContent = alert.message;
+    fallback.append(title, message);
+    return fallback;
+  }
+  const element = template.content.firstElementChild.cloneNode(true);
+  element.dataset.cardId = alert.id;
+  element.querySelector('.alert-title').textContent = alert.name;
+  element.querySelector('.alert-message').textContent = alert.message;
+  return element;
+}
+
+function loadCollection() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEYS.collection) ?? localStorage.getItem(LEGACY_STORAGE_KEYS.collection);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.map(normalizeCollectionEntry);
+  } catch (error) {
+    console.warn('Konnte Sammlung nicht laden.', error);
+    return [];
+  }
+}
+
+function saveCollection() {
+  try {
+    localStorage.setItem(STORAGE_KEYS.collection, JSON.stringify(state.collection));
+  } catch (error) {
+    console.warn('Konnte Sammlung nicht speichern.', error);
+  }
+}
+
+function loadWishlist() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEYS.wishlist);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.map(normalizeWishlistEntry);
+  } catch (error) {
+    console.warn('Konnte Wunschliste nicht laden.', error);
+    return [];
+  }
+}
+
+function saveWishlist() {
+  try {
+    localStorage.setItem(STORAGE_KEYS.wishlist, JSON.stringify(state.wishlist));
+  } catch (error) {
+    console.warn('Konnte Wunschliste nicht speichern.', error);
+  }
+}
+
+function loadDecks() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEYS.decks);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.map((deck) => ({
+      ...deck,
+      cards: Array.isArray(deck.cards) ? deck.cards : []
+    }));
+  } catch (error) {
+    console.warn('Konnte Decks nicht laden.', error);
+    return [];
+  }
+}
+
+function saveDecks() {
+  try {
+    localStorage.setItem(STORAGE_KEYS.decks, JSON.stringify(state.decks));
+  } catch (error) {
+    console.warn('Konnte Decks nicht speichern.', error);
+  }
+}
+
+function loadSettings() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEYS.settings);
+    if (!raw) {
+      return { ...DEFAULT_SETTINGS };
+    }
+    const parsed = JSON.parse(raw);
+    return {
+      ...DEFAULT_SETTINGS,
+      ...parsed,
+      exchangeRates: {
+        ...DEFAULT_SETTINGS.exchangeRates,
+        ...(parsed?.exchangeRates ?? {})
+      }
+    };
+  } catch (error) {
+    console.warn('Konnte Einstellungen nicht laden.', error);
+    return { ...DEFAULT_SETTINGS };
+  }
+}
+
+function saveSettings() {
+  try {
+    localStorage.setItem(STORAGE_KEYS.settings, JSON.stringify(state.settings));
+  } catch (error) {
+    console.warn('Konnte Einstellungen nicht speichern.', error);
+  }
 }
 
 function loadApiKey() {
   try {
-    return localStorage.getItem(STORAGE_KEYS.apiKey) ?? '';
+    return localStorage.getItem(STORAGE_KEYS.apiKey) ?? localStorage.getItem(LEGACY_STORAGE_KEYS.apiKey) ?? '';
   } catch (error) {
     console.warn('Konnte API-Schlüssel nicht laden.', error);
     return '';
@@ -76,523 +2160,665 @@ function saveApiKey(key) {
   }
 }
 
-function loadCollection() {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEYS.collection);
-    if (!raw) {
-      return [];
+function normalizeCollectionEntry(entry) {
+  return {
+    id: entry.id,
+    name: entry.name,
+    number: entry.number ?? '',
+    setId: entry.setId ?? entry.set?.id ?? '',
+    setName: entry.setName ?? entry.set?.name ?? '',
+    setSeries: entry.setSeries ?? entry.set?.series ?? '',
+    rarity: entry.rarity ?? '',
+    supertype: entry.supertype ?? '',
+    subtypes: entry.subtypes ?? [],
+    types: entry.types ?? [],
+    regulationMark: entry.regulationMark ?? '',
+    artist: entry.artist ?? '',
+    images: entry.images ?? {},
+    url: entry.url ?? createDetailsUrl(entry.id),
+    quantity: Number(entry.quantity) || 1,
+    condition: entry.condition ?? 'nearMint',
+    language: entry.language ?? 'Deutsch',
+    edition: entry.edition ?? 'standard',
+    purchasePrice: entry.purchasePrice ?? null,
+    purchaseDate: entry.purchaseDate ?? null,
+    purchaseHistory: Array.isArray(entry.purchaseHistory) ? entry.purchaseHistory : [],
+    targetPrice: entry.targetPrice ?? null,
+    targetPriceCurrency: entry.targetPriceCurrency ?? state.settings.currency,
+    priority: entry.priority ?? 'medium',
+    notes: entry.notes ?? '',
+    market: entry.market ?? { lowest: null, average: null, highest: null, currency: state.settings.currency, timestamp: null },
+    marketSources: entry.marketSources ?? [],
+    priceHistory: Array.isArray(entry.priceHistory) ? entry.priceHistory : [],
+    addedAt: entry.addedAt ?? new Date().toISOString(),
+    updatedAt: entry.updatedAt ?? entry.addedAt ?? new Date().toISOString()
+  };
+}
+
+function normalizeWishlistEntry(entry) {
+  return {
+    id: entry.id,
+    name: entry.name,
+    number: entry.number ?? '',
+    setId: entry.setId ?? entry.set?.id ?? '',
+    setName: entry.setName ?? entry.set?.name ?? '',
+    setSeries: entry.setSeries ?? entry.set?.series ?? '',
+    rarity: entry.rarity ?? '',
+    supertype: entry.supertype ?? '',
+    subtypes: entry.subtypes ?? [],
+    types: entry.types ?? [],
+    regulationMark: entry.regulationMark ?? '',
+    images: entry.images ?? {},
+    url: entry.url ?? createDetailsUrl(entry.id),
+    quantity: Number(entry.quantity) || 1,
+    targetPrice: entry.targetPrice ?? null,
+    targetPriceCurrency: entry.targetPriceCurrency ?? state.settings.currency,
+    priority: entry.priority ?? 'medium',
+    notes: entry.notes ?? '',
+    market: entry.market ?? { lowest: null, average: null, highest: null, currency: state.settings.currency, timestamp: null },
+    marketSources: entry.marketSources ?? [],
+    priceHistory: Array.isArray(entry.priceHistory) ? entry.priceHistory : [],
+    addedAt: entry.addedAt ?? new Date().toISOString(),
+    updatedAt: entry.updatedAt ?? entry.addedAt ?? new Date().toISOString()
+  };
+}
+
+function applyTheme() {
+  let theme = state.settings.theme;
+  if (theme === 'system') {
+    theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  document.documentElement.dataset.theme = theme;
+}
+
+function updateSetting(key, value) {
+  state.settings[key] = value;
+  saveSettings();
+  if (key === 'theme') {
+    applyTheme();
+  }
+  if (key === 'valuationMode') {
+    renderCollection();
+    renderDashboard();
+    renderWishlist();
+  }
+}
+
+function updateCurrency(currency) {
+  if (!currency) {
+    return;
+  }
+  const previousCurrency = state.settings.currency;
+  state.settings.currency = currency;
+  // Konvertiere Zielpreise in neue Basiswährung
+  state.collection.forEach((entry) => {
+    if (entry.targetPrice !== null && entry.targetPriceCurrency && entry.targetPriceCurrency !== currency) {
+      entry.targetPrice = convertCurrency(entry.targetPrice, entry.targetPriceCurrency, currency);
+      entry.targetPriceCurrency = currency;
     }
-
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) {
-      return [];
-    }
-
-    return parsed.map((entry) => ({
-      ...entry,
-      quantity: Number(entry.quantity) || 1
-    }));
-  } catch (error) {
-    console.warn('Konnte Sammlung nicht laden.', error);
-    return [];
-  }
-}
-
-function saveCollection() {
-  try {
-    localStorage.setItem(STORAGE_KEYS.collection, JSON.stringify(state.collection));
-  } catch (error) {
-    console.warn('Konnte Sammlung nicht speichern.', error);
-  }
-}
-
-function initialiseApiKeyControls() {
-  if (state.apiKey) {
-    dom.apiKeyInput.value = state.apiKey;
-    setFeedback(dom.apiKeyFeedback, 'Eigener API-Schlüssel aktiv.', 'success');
-  }
-
-  dom.saveApiKeyButton.addEventListener('click', () => {
-    const key = dom.apiKeyInput.value.trim();
-    state.apiKey = key;
-    saveApiKey(key);
-    setFeedback(dom.apiKeyFeedback, key ? 'API-Schlüssel gespeichert.' : 'Bitte einen gültigen Schlüssel eingeben.', key ? 'success' : 'error');
-  });
-
-  dom.clearApiKeyButton.addEventListener('click', () => {
-    dom.apiKeyInput.value = '';
-    state.apiKey = '';
-    saveApiKey('');
-    setFeedback(dom.apiKeyFeedback, 'API-Schlüssel entfernt. Öffentliche Limits gelten.', 'success');
-  });
-}
-
-async function loadSetsAndFilters() {
-  setFeedback(dom.searchFeedback, 'Lade Sets und Filter …');
-  try {
-    const [setsResponse, typesResponse, raritiesResponse] = await Promise.all([
-      apiFetch('/sets', { orderBy: '-releaseDate', pageSize: 250 }),
-      apiFetch('/types'),
-      apiFetch('/rarities')
-    ]);
-
-    state.sets = Array.isArray(setsResponse?.data) ? setsResponse.data : [];
-    renderSets(state.sets.slice(0, FEATURED_SET_LIMIT));
-    populateSetFilter(state.sets);
-    populateTypeFilter(typesResponse?.data ?? []);
-    populateRarityFilter(raritiesResponse?.data ?? []);
-    setFeedback(dom.searchFeedback, 'Bereit! Starte eine Suche oder scanne eine Karte.');
-  } catch (error) {
-    console.error(error);
-    const message = getErrorMessage(error);
-    setFeedback(dom.searchFeedback, `Sets konnten nicht geladen werden: ${message}`, 'error');
-  }
-}
-
-function populateSetFilter(sets) {
-  if (!dom.setFilter) {
-    return;
-  }
-
-  clearSelectOptions(dom.setFilter, 'Alle Sets');
-  sets.forEach((set) => {
-    const option = document.createElement('option');
-    option.value = set.id;
-    option.textContent = `${set.name} (${set.series})`;
-    dom.setFilter.append(option);
-  });
-}
-
-function populateTypeFilter(types) {
-  if (!dom.typeFilter) {
-    return;
-  }
-
-  clearSelectOptions(dom.typeFilter, 'Alle Typen');
-  types.forEach((type) => {
-    const option = document.createElement('option');
-    option.value = type;
-    option.textContent = type;
-    dom.typeFilter.append(option);
-  });
-}
-
-function populateRarityFilter(rarities) {
-  if (!dom.rarityFilter) {
-    return;
-  }
-
-  clearSelectOptions(dom.rarityFilter, 'Alle Seltenheiten');
-  rarities.forEach((rarity) => {
-    const option = document.createElement('option');
-    option.value = rarity;
-    option.textContent = rarity;
-    dom.rarityFilter.append(option);
-  });
-}
-
-function clearSelectOptions(selectElement, placeholder) {
-  selectElement.innerHTML = '';
-  const option = document.createElement('option');
-  option.value = '';
-  option.textContent = placeholder;
-  selectElement.append(option);
-}
-
-function renderSets(sets) {
-  dom.setsGrid.innerHTML = '';
-  if (!sets.length) {
-    const empty = document.createElement('div');
-    empty.className = 'empty-state';
-    empty.textContent = 'Keine Sets gefunden.';
-    dom.setsGrid.append(empty);
-    return;
-  }
-
-  const fragment = document.createDocumentFragment();
-  sets.forEach((set) => {
-    fragment.append(createSetCard(set));
-  });
-  dom.setsGrid.append(fragment);
-}
-
-function createSetCard(set) {
-  const element = document.createElement('article');
-  element.className = 'set-card';
-
-  const image = document.createElement('img');
-  image.src = set.images?.symbol || set.images?.logo || '';
-  image.alt = `${set.name} Symbol`;
-  element.append(image);
-
-  const info = document.createElement('div');
-  const title = document.createElement('h3');
-  title.textContent = set.name;
-  info.append(title);
-
-  const details = document.createElement('p');
-  const date = formatDate(set.releaseDate);
-  const total = `${set.total || '?'} Karten`;
-  details.textContent = `${set.series} · ${total}${date ? ` · ${date}` : ''}`;
-  info.append(details);
-
-  const action = document.createElement('button');
-  action.type = 'button';
-  action.className = 'secondary';
-  action.textContent = 'Im Suchfilter wählen';
-  action.addEventListener('click', () => {
-    dom.setFilter.value = set.id;
-    if (dom.searchForm?.requestSubmit) {
-      dom.searchForm.requestSubmit();
-    } else {
-      dom.searchForm?.dispatchEvent(new Event('submit'));
+    if (entry.marketSources?.length) {
+      entry.market = aggregatePriceSources(entry.marketSources, currency);
     }
   });
-  info.append(action);
-
-  element.append(info);
-  return element;
+  state.wishlist.forEach((entry) => {
+    if (entry.targetPrice !== null && entry.targetPriceCurrency && entry.targetPriceCurrency !== currency) {
+      entry.targetPrice = convertCurrency(entry.targetPrice, entry.targetPriceCurrency, currency);
+      entry.targetPriceCurrency = currency;
+    }
+    if (entry.marketSources?.length) {
+      entry.market = aggregatePriceSources(entry.marketSources, currency);
+    }
+  });
+  saveSettings();
+  saveCollection();
+  saveWishlist();
+  renderCollection();
+  renderWishlist();
+  renderDashboard();
+  setFeedback(dom.settingsFeedback, `Währung auf ${currency} umgestellt.`, 'success');
 }
 
-function setupSearchForm() {
-  if (!dom.searchForm) {
+function updateExchangeRate(currency, value) {
+  if (!Number.isFinite(value) || value <= 0) {
+    setFeedback(dom.settingsFeedback, 'Bitte einen gültigen Wechselkurs eingeben.', 'error');
     return;
   }
+  state.settings.exchangeRates[currency] = value;
+  saveSettings();
+  updateCurrency(state.settings.currency);
+}
 
-  dom.searchForm.addEventListener('submit', async (event) => {
-    event.preventDefault();
-    if (state.isSearching) {
+function resetSettings() {
+  if (!confirm('Einstellungen auf Standardwerte zurücksetzen?')) {
+    return;
+  }
+  state.settings = { ...DEFAULT_SETTINGS };
+  dom.themeSelect.value = state.settings.theme;
+  dom.currencySelect.value = state.settings.currency;
+  dom.valuationModeSelect.value = state.settings.valuationMode;
+  dom.usdRateInput.value = state.settings.exchangeRates.USD;
+  dom.gbpRateInput.value = state.settings.exchangeRates.GBP;
+  dom.priceIntervalInput.value = state.settings.priceIntervalDays;
+  dom.settingsNotes.value = state.settings.notes;
+  saveSettings();
+  applyTheme();
+  renderCollection();
+  renderWishlist();
+  renderDashboard();
+  setFeedback(dom.settingsFeedback, 'Einstellungen zurückgesetzt.', 'success');
+}
+
+function clearAllData() {
+  if (!confirm('Möchtest du wirklich alle Daten löschen? Dies kann nicht rückgängig gemacht werden.')) {
+    return;
+  }
+  state.collection = [];
+  state.wishlist = [];
+  state.decks = [];
+  state.settings = { ...DEFAULT_SETTINGS };
+  state.selectedDeckId = null;
+  saveCollection();
+  saveWishlist();
+  saveDecks();
+  saveSettings();
+  localStorage.removeItem(STORAGE_KEYS.apiKey);
+  renderAll();
+  setFeedback(dom.settingsFeedback, 'Alle Daten wurden gelöscht.', 'success');
+}
+
+function maybeSchedulePriceRefresh() {
+  if (!state.settings.lastPriceUpdate) {
+    return;
+  }
+  const last = new Date(state.settings.lastPriceUpdate);
+  const diffDays = (Date.now() - last.getTime()) / (1000 * 60 * 60 * 24);
+  if (diffDays >= state.settings.priceIntervalDays) {
+    updateAllPrices();
+  }
+}
+
+function extractMarketPrices(card) {
+  const sources = [];
+  const baseCurrency = state.settings.currency;
+
+  if (card.tcgplayer?.prices) {
+    Object.entries(card.tcgplayer.prices).forEach(([variant, price]) => {
+      sources.push({
+        source: `TCGplayer ${variant}`,
+        currency: 'USD',
+        low: price?.low ?? null,
+        average: price?.market ?? price?.mid ?? null,
+        high: price?.high ?? null
+      });
+    });
+  }
+  if (card.cardmarket?.prices) {
+    const price = card.cardmarket.prices;
+    sources.push({
+      source: 'Cardmarket',
+      currency: 'EUR',
+      low: price?.lowPrice ?? price?.trendPrice ?? null,
+      average: price?.trendPrice ?? null,
+      high: price?.avg30 ?? price?.trendPrice ?? null
+    });
+  }
+
+  const aggregated = aggregatePriceSources(sources, baseCurrency);
+  return { aggregated, sources };
+}
+
+function aggregatePriceSources(sources, targetCurrency) {
+  let lowest = null;
+  let averageSum = 0;
+  let averageCount = 0;
+  let highest = null;
+  sources.forEach((source) => {
+    if (Number.isFinite(source.low)) {
+      const converted = convertCurrency(source.low, source.currency, targetCurrency);
+      lowest = lowest === null ? converted : Math.min(lowest, converted);
+    }
+    if (Number.isFinite(source.average)) {
+      const converted = convertCurrency(source.average, source.currency, targetCurrency);
+      averageSum += converted;
+      averageCount += 1;
+    }
+    if (Number.isFinite(source.high)) {
+      const converted = convertCurrency(source.high, source.currency, targetCurrency);
+      highest = highest === null ? converted : Math.max(highest, converted);
+    }
+  });
+  const average = averageCount ? averageSum / averageCount : null;
+  return {
+    lowest,
+    average,
+    highest,
+    currency: targetCurrency,
+    timestamp: new Date().toISOString()
+  };
+}
+
+function updateAllPrices() {
+  if (!state.collection.length && !state.wishlist.length) {
+    setFeedback(dom.settingsFeedback, 'Keine Einträge für Preisupdates vorhanden.', 'error');
+    return;
+  }
+  setFeedback(dom.settingsFeedback, 'Aktualisiere Preise …');
+  const tasks = state.collection.map((entry) => () => updateEntryPrice(entry, false))
+    .concat(state.wishlist.map((entry) => () => updateWishlistPrice(entry, false)));
+
+  runSequential(tasks).then(() => {
+    state.settings.lastPriceUpdate = new Date().toISOString();
+    saveSettings();
+    saveCollection();
+    saveWishlist();
+    renderCollection();
+    renderWishlist();
+    renderDashboard();
+    setFeedback(dom.settingsFeedback, 'Preise aktualisiert.', 'success');
+  }).catch((error) => {
+    console.error('Preisupdate fehlgeschlagen', error);
+    setFeedback(dom.settingsFeedback, `Preisupdate fehlgeschlagen: ${getErrorMessage(error)}`, 'error');
+  });
+}
+
+function updateEntryPrice(entry, render = true) {
+  return getCardDetails(entry.id).then((card) => {
+    if (!card) {
       return;
     }
-
-    const formData = new FormData(dom.searchForm);
-    const query = (formData.get('query') || '').toString().trim();
-    const setId = (formData.get('set') || '').toString().trim();
-    const type = (formData.get('type') || '').toString().trim();
-    const rarity = (formData.get('rarity') || '').toString().trim();
-
-    const clauses = [];
-    if (query) {
-      const escaped = escapeQueryValue(query);
-      clauses.push(`(name:*\"${escaped}\"* OR subtypes:*\"${escaped}\"*)`);
+    const { aggregated, sources } = extractMarketPrices(card);
+    entry.market = aggregated;
+    entry.marketSources = sources;
+    entry.priceHistory = entry.priceHistory || [];
+    if (aggregated.average !== null) {
+      entry.priceHistory.push({
+        timestamp: aggregated.timestamp,
+        ...aggregated
+      });
     }
-    if (setId) {
-      clauses.push(`set.id:${setId}`);
+    entry.updatedAt = new Date().toISOString();
+    saveCollection();
+    if (render) {
+      renderCollection();
+      renderDashboard();
     }
-    if (type) {
-      clauses.push(`types:${type}`);
-    }
-    if (rarity) {
-      clauses.push(`rarity:\"${escapeQueryValue(rarity)}\"`);
-    }
-
-    const searchParams = new URLSearchParams({
-      pageSize: '40',
-      orderBy: 'name'
-    });
-
-    if (clauses.length) {
-      searchParams.set('q', clauses.join(' AND '));
-    }
-
-    await performCardSearch(searchParams, query);
   });
 }
 
-async function performCardSearch(searchParams, queryText) {
-  state.isSearching = true;
-  setFeedback(dom.searchFeedback, 'Suche Karten …');
-  try {
-    const response = await apiFetch('/cards', searchParams);
-    const cards = response?.data ?? [];
-    renderCardList(cards, dom.resultsGrid, {
-      emptyMessage: queryText ? 'Keine Karten für die Suche gefunden.' : 'Bitte starte eine Suche, um Karten zu sehen.',
-      feedbackElement: dom.searchFeedback
-    });
-    if (cards.length) {
-      setFeedback(dom.searchFeedback, `${cards.length} Karten gefunden.`);
-    } else {
-      setFeedback(dom.searchFeedback, 'Keine passenden Karten gefunden.', 'error');
+function updateWishlistPrice(entry, render = true) {
+  return getCardDetails(entry.id).then((card) => {
+    if (!card) {
+      return;
     }
-  } catch (error) {
-    console.error(error);
-    const message = getErrorMessage(error);
-    setFeedback(dom.searchFeedback, `Suche fehlgeschlagen: ${message}`, 'error');
-  } finally {
-    state.isSearching = false;
-  }
-}
-
-function renderCardList(cards, container, options = {}) {
-  const { emptyMessage, feedbackElement } = options;
-  container.innerHTML = '';
-
-  if (!cards.length) {
-    if (emptyMessage) {
-      const empty = document.createElement('div');
-      empty.className = 'empty-state';
-      empty.textContent = emptyMessage;
-      container.append(empty);
+    const { aggregated, sources } = extractMarketPrices(card);
+    entry.market = aggregated;
+    entry.marketSources = sources;
+    entry.priceHistory = entry.priceHistory || [];
+    if (aggregated.average !== null) {
+      entry.priceHistory.push({
+        timestamp: aggregated.timestamp,
+        ...aggregated
+      });
     }
-    return;
-  }
-
-  const fragment = document.createDocumentFragment();
-  cards.forEach((card) => {
-    const element = createCardElement(card, {
-      onAdd: (addedCard) => {
-        const { action } = addCardToCollection(addedCard);
-        if (feedbackElement) {
-          const message = action === 'new'
-            ? `${addedCard.name} wurde deiner Sammlung hinzugefügt.`
-            : `Anzahl von ${addedCard.name} erhöht.`;
-          setFeedback(feedbackElement, message, 'success');
-        }
-      }
-    });
-    fragment.append(element);
+    entry.updatedAt = new Date().toISOString();
+    saveWishlist();
+    if (render) {
+      renderWishlist();
+      renderDashboard();
+    }
   });
-  container.append(fragment);
 }
 
-function createCardElement(card, options = {}) {
-  const template = document.getElementById('cardTemplate');
-  if (!template) {
-    throw new Error('Kartenvorlage fehlt');
+function runSequential(tasks) {
+  return tasks.reduce((promise, task) => promise.then(() => task()), Promise.resolve());
+}
+
+function getCardDetails(cardId) {
+  if (cardCache.has(cardId)) {
+    return Promise.resolve(cardCache.get(cardId));
+  }
+  return apiFetch(`/cards/${cardId}`).then((response) => {
+    const card = response?.data;
+    if (card) {
+      cardCache.set(card.id, card);
+    }
+    return card;
+  }).catch((error) => {
+    console.warn('Kartendetails konnten nicht geladen werden', error);
+    return null;
+  });
+}
+
+function convertCurrency(amount, fromCurrency, toCurrency) {
+  if (!Number.isFinite(amount)) {
+    return null;
+  }
+  if (fromCurrency === toCurrency) {
+    return amount;
+  }
+  const rates = {
+    EUR: 1,
+    USD: state.settings.exchangeRates.USD || DEFAULT_SETTINGS.exchangeRates.USD,
+    GBP: state.settings.exchangeRates.GBP || DEFAULT_SETTINGS.exchangeRates.GBP
+  };
+  let amountInEur;
+  switch (fromCurrency) {
+    case 'USD':
+      amountInEur = amount * rates.USD;
+      break;
+    case 'GBP':
+      amountInEur = amount * rates.GBP;
+      break;
+    case 'EUR':
+      amountInEur = amount;
+      break;
+    default:
+      amountInEur = amount;
+      break;
   }
 
-  const { onAdd } = options;
-  const element = template.content.firstElementChild.cloneNode(true);
-  const image = element.querySelector('.card-image');
-  image.src = card.images?.small || card.images?.large || '';
-  image.alt = `${card.name} (${card.set?.name ?? 'Pokémon TCG'})`;
+  switch (toCurrency) {
+    case 'USD':
+      return amountInEur / rates.USD;
+    case 'GBP':
+      return amountInEur / rates.GBP;
+    case 'EUR':
+    default:
+      return amountInEur;
+  }
+}
 
-  element.querySelector('.card-title').textContent = card.name;
-  element.querySelector('.card-subtitle').textContent = card.set ? `${card.set.series} · ${card.set.name}` : 'Pokémon TCG Karte';
-  const metaParts = [];
-  if (card.number) {
-    metaParts.push(`Nr. ${card.number}`);
+function getEntryValue(entry) {
+  const mode = state.settings.valuationMode;
+  const price = entry.market?.[mode];
+  if (!Number.isFinite(price)) {
+    return 0;
   }
-  if (card.rarity) {
-    metaParts.push(card.rarity);
-  }
-  if (card.types?.length) {
-    metaParts.push(card.types.join(', '));
-  }
-  element.querySelector('.card-meta').textContent = metaParts.join(' · ');
+  return price * entry.quantity;
+}
 
-  const addButton = element.querySelector('.add-button');
-  if (addButton) {
-    addButton.addEventListener('click', () => {
-      if (typeof onAdd === 'function') {
-        onAdd(card);
-      }
-    });
+function getValuationLabel() {
+  switch (state.settings.valuationMode) {
+    case 'lowest':
+      return 'Niedrigster Preis';
+    case 'highest':
+      return 'Höchster Preis';
+    default:
+      return 'Durchschnittspreis';
   }
+}
 
-  const detailsLink = element.querySelector('.details-link');
-  if (detailsLink) {
-    detailsLink.href = createDetailsUrl(card.id);
-    detailsLink.textContent = 'Details anzeigen';
+function getConditionLabel(condition) {
+  const option = CONDITION_OPTIONS.find((item) => item.value === condition);
+  return option ? option.label : condition;
+}
+
+function formatCurrency(amount) {
+  if (!Number.isFinite(amount)) {
+    return '–';
   }
+  return new Intl.NumberFormat('de-DE', {
+    style: 'currency',
+    currency: state.settings.currency,
+    maximumFractionDigits: 2
+  }).format(amount);
+}
 
-  return element;
+function formatDate(dateString) {
+  if (!dateString) {
+    return '';
+  }
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return new Intl.DateTimeFormat('de-DE', { year: 'numeric', month: 'short' }).format(date);
+}
+
+function formatRelativeTime(dateString) {
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  const diffMs = Date.now() - date.getTime();
+  const diffMinutes = Math.round(diffMs / (1000 * 60));
+  if (diffMinutes < 60) {
+    return `vor ${diffMinutes} Minuten`;
+  }
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 24) {
+    return `vor ${diffHours} Stunden`;
+  }
+  const diffDays = Math.round(diffHours / 24);
+  if (diffDays < 30) {
+    return `vor ${diffDays} Tagen`;
+  }
+  const diffMonths = Math.round(diffDays / 30);
+  if (diffMonths < 12) {
+    return `vor ${diffMonths} Monaten`;
+  }
+  const diffYears = Math.round(diffMonths / 12);
+  return `vor ${diffYears} Jahren`;
+}
+
+function escapeHtml(text) {
+  return text.replace(/[&<>"]+/g, (match) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;'
+  })[match] || match);
+}
+
+function escapeQueryValue(value) {
+  return value.replace(/"/g, '\\"');
 }
 
 function createDetailsUrl(cardId) {
   return `https://pokemontcg.io/card/${cardId}`;
 }
 
-function toCollectionEntry(card) {
-  return {
-    id: card.id,
-    name: card.name,
-    number: card.number ?? '',
-    setName: card.set?.name ?? '',
-    setSeries: card.set?.series ?? '',
-    rarity: card.rarity ?? '',
-    types: card.types ?? [],
-    images: card.images ?? {},
-    url: createDetailsUrl(card.id),
-    quantity: 1
-  };
+function showGlobalFeedback(message, type) {
+  const feedback = document.createElement('div');
+  feedback.className = `feedback ${type ?? ''}`;
+  feedback.textContent = message;
+  document.body.prepend(feedback);
+  setTimeout(() => feedback.remove(), 4000);
 }
 
-function addCardToCollection(card) {
-  const existing = state.collection.find((entry) => entry.id === card.id);
-  if (existing) {
-    existing.quantity += 1;
-    saveCollection();
-    renderCollection();
-    setFeedback(dom.collectionFeedback, `${existing.name} aktualisiert.`, 'success');
-    return { action: 'increment', entry: existing };
+function setFeedback(element, message, type) {
+  if (!element) {
+    return;
   }
-
-  const entry = toCollectionEntry(card);
-  state.collection.push(entry);
-  saveCollection();
-  renderCollection();
-  setFeedback(dom.collectionFeedback, `${entry.name} wurde zur Sammlung hinzugefügt.`, 'success');
-  return { action: 'new', entry };
+  element.textContent = message || '';
+  element.classList.remove('error', 'success');
+  if (type) {
+    element.classList.add(type);
+  }
 }
 
-function renderCollection() {
-  dom.collectionGrid.innerHTML = '';
+function exportCollectionCsv() {
   if (!state.collection.length) {
-    dom.collectionEmptyState.style.display = 'block';
-    setFeedback(dom.collectionFeedback, '');
+    setFeedback(dom.exportFeedback, 'Keine Karten in der Sammlung.', 'error');
     return;
   }
-
-  dom.collectionEmptyState.style.display = 'none';
-  const sorted = [...state.collection].sort((a, b) => a.name.localeCompare(b.name, 'de'));
-  const fragment = document.createDocumentFragment();
-  sorted.forEach((entry) => {
-    fragment.append(createCollectionCard(entry));
+  const rows = [['Name', 'Set', 'Nummer', 'Menge', 'Zustand', 'Sprache', 'Edition', 'Kaufpreis', 'Kaufdatum', 'Notizen', 'Wert', 'URL']];
+  state.collection.forEach((entry) => {
+    rows.push([
+      entry.name,
+      entry.setName,
+      entry.number,
+      entry.quantity,
+      getConditionLabel(entry.condition),
+      entry.language,
+      entry.edition,
+      entry.purchasePrice ?? '',
+      entry.purchaseDate ?? '',
+      entry.notes ?? '',
+      getEntryValue(entry),
+      entry.url
+    ]);
   });
-  dom.collectionGrid.append(fragment);
+  downloadCsv(rows, 'pokefolio-sammlung.csv');
+  setFeedback(dom.exportFeedback, 'Sammlung exportiert.', 'success');
 }
 
-function createCollectionCard(entry) {
-  const template = document.getElementById('cardTemplate');
-  const element = template.content.firstElementChild.cloneNode(true);
-  const image = element.querySelector('.card-image');
-  image.src = entry.images?.small || entry.images?.large || '';
-  image.alt = `${entry.name} (${entry.setName || 'Pokémon TCG'})`;
-
-  element.querySelector('.card-title').textContent = entry.name;
-  const subtitleParts = [];
-  if (entry.setSeries) {
-    subtitleParts.push(entry.setSeries);
+function exportWishlistCsv() {
+  if (!state.wishlist.length) {
+    setFeedback(dom.exportFeedback, 'Keine Karten auf der Wunschliste.', 'error');
+    return;
   }
-  if (entry.setName) {
-    subtitleParts.push(entry.setName);
-  }
-  element.querySelector('.card-subtitle').textContent = subtitleParts.join(' · ');
-
-  const metaParts = [];
-  if (entry.number) {
-    metaParts.push(`Nr. ${entry.number}`);
-  }
-  if (entry.rarity) {
-    metaParts.push(entry.rarity);
-  }
-  if (entry.types?.length) {
-    metaParts.push(entry.types.join(', '));
-  }
-  metaParts.push(`Anzahl: ${entry.quantity}`);
-  element.querySelector('.card-meta').textContent = metaParts.join(' · ');
-
-  const detailsLink = element.querySelector('.details-link');
-  detailsLink.href = entry.url;
-  detailsLink.textContent = 'Details anzeigen';
-
-  const addButton = element.querySelector('.add-button');
-  if (addButton) {
-    addButton.remove();
-  }
-
-  const actions = element.querySelector('.card-actions');
-  const quantityControls = document.createElement('div');
-  quantityControls.className = 'quantity-controls';
-
-  const decrementButton = document.createElement('button');
-  decrementButton.type = 'button';
-  decrementButton.className = 'quantity-button';
-  decrementButton.textContent = '−';
-  decrementButton.addEventListener('click', () => updateCollectionQuantity(entry.id, -1));
-
-  const quantityValue = document.createElement('span');
-  quantityValue.className = 'quantity-value';
-  quantityValue.textContent = entry.quantity;
-
-  const incrementButton = document.createElement('button');
-  incrementButton.type = 'button';
-  incrementButton.className = 'quantity-button';
-  incrementButton.textContent = '+';
-  incrementButton.addEventListener('click', () => updateCollectionQuantity(entry.id, 1));
-
-  quantityControls.append(decrementButton, quantityValue, incrementButton);
-  actions.prepend(quantityControls);
-
-  const removeButton = document.createElement('button');
-  removeButton.type = 'button';
-  removeButton.className = 'secondary remove-button';
-  removeButton.textContent = 'Entfernen';
-  removeButton.addEventListener('click', () => removeCardFromCollection(entry.id));
-  actions.append(removeButton);
-
-  return element;
+  const rows = [['Name', 'Set', 'Nummer', 'Menge', 'Priorität', 'Zielpreis', 'Marktpreis', 'Notizen', 'URL']];
+  state.wishlist.forEach((entry) => {
+    rows.push([
+      entry.name,
+      entry.setName,
+      entry.number,
+      entry.quantity,
+      PRIORITY_LABELS[entry.priority] ?? entry.priority,
+      entry.targetPrice ?? '',
+      entry.market?.[state.settings.valuationMode] ?? '',
+      entry.notes ?? '',
+      entry.url
+    ]);
+  });
+  downloadCsv(rows, 'pokefolio-wunschliste.csv');
+  setFeedback(dom.exportFeedback, 'Wunschliste exportiert.', 'success');
 }
 
-function updateCollectionQuantity(cardId, delta) {
-  const entry = state.collection.find((item) => item.id === cardId);
-  if (!entry) {
+function exportDeckLists() {
+  if (!state.decks.length) {
+    setFeedback(dom.exportFeedback, 'Keine Decks vorhanden.', 'error');
     return;
   }
-
-  entry.quantity = Math.max(0, entry.quantity + delta);
-  if (entry.quantity <= 0) {
-    removeCardFromCollection(cardId);
-    return;
-  }
-
-  saveCollection();
-  renderCollection();
-  setFeedback(dom.collectionFeedback, `Anzahl von ${entry.name} aktualisiert.`, 'success');
-}
-
-function removeCardFromCollection(cardId) {
-  const index = state.collection.findIndex((item) => item.id === cardId);
-  if (index === -1) {
-    return;
-  }
-  const [removed] = state.collection.splice(index, 1);
-  saveCollection();
-  renderCollection();
-  setFeedback(dom.collectionFeedback, `${removed.name} wurde aus der Sammlung entfernt.`, 'success');
-}
-
-function setupScanner() {
-  if (!dom.startScannerButton) {
-    return;
-  }
-
-  dom.startScannerButton.addEventListener('click', () => startScanner());
-  dom.stopScannerButton.addEventListener('click', () => stopScanner());
-  dom.captureCardButton.addEventListener('click', () => captureCard());
-}
-
-async function startScanner() {
-  if (!navigator.mediaDevices?.getUserMedia) {
-    setFeedback(dom.scannerFeedback, 'Kamera wird nicht unterstützt. Verwende stattdessen die Suche.', 'error');
-    return;
-  }
-
-  try {
-    const stream = await navigator.mediaDevices.getUserMedia({
-      video: { facingMode: 'environment' },
-      audio: false
+  const lines = [];
+  state.decks.forEach((deck) => {
+    lines.push(`# ${deck.name} (${deck.format})`);
+    lines.push('## Hauptdeck');
+    deck.cards.filter((card) => card.category === 'main').sort((a, b) => a.name.localeCompare(b.name, 'de')).forEach((card) => {
+      lines.push(`${card.quantity}x ${card.name} (${card.setName} ${card.number})`);
     });
-    scannerState.stream = stream;
-    scannerState.isActive = true;
-    dom.scannerVideo.srcObject = stream;
-    dom.captureCardButton.disabled = false;
-    dom.stopScannerButton.disabled = false;
-    dom.startScannerButton.disabled = true;
-    setFeedback(dom.scannerFeedback, 'Kamera aktiv. Positioniere die Karte im Rahmen.');
-  } catch (error) {
-    console.error('Scanner konnte nicht gestartet werden', error);
-    setFeedback(dom.scannerFeedback, `Kamera konnte nicht gestartet werden: ${getErrorMessage(error)}`, 'error');
+    if (deck.cards.some((card) => card.category === 'side')) {
+      lines.push('## Sideboard');
+      deck.cards.filter((card) => card.category === 'side').sort((a, b) => a.name.localeCompare(b.name, 'de')).forEach((card) => {
+        lines.push(`${card.quantity}x ${card.name} (${card.setName} ${card.number})`);
+      });
+    }
+    if (deck.cards.some((card) => card.category === 'extra')) {
+      lines.push('## Extra');
+      deck.cards.filter((card) => card.category === 'extra').sort((a, b) => a.name.localeCompare(b.name, 'de')).forEach((card) => {
+        lines.push(`${card.quantity}x ${card.name} (${card.setName} ${card.number})`);
+      });
+    }
+    if (deck.notes) {
+      lines.push(`## Notizen\n${deck.notes}`);
+    }
+    lines.push('');
+  });
+  const blob = new Blob([lines.join('\n')], { type: 'text/plain;charset=utf-8' });
+  downloadBlob(blob, 'pokefolio-decks.txt');
+  setFeedback(dom.exportFeedback, 'Decklisten exportiert.', 'success');
+}
+
+function exportBackupJson() {
+  const data = {
+    collection: state.collection,
+    wishlist: state.wishlist,
+    decks: state.decks,
+    settings: state.settings,
+    exportedAt: new Date().toISOString()
+  };
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json;charset=utf-8' });
+  downloadBlob(blob, 'pokefolio-backup.json');
+  setFeedback(dom.exportFeedback, 'Backup erstellt.', 'success');
+}
+
+function importBackupJson(event) {
+  const file = event.target.files?.[0];
+  if (!file) {
+    return;
   }
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const parsed = JSON.parse(reader.result);
+      if (parsed.collection) {
+        state.collection = parsed.collection.map(normalizeCollectionEntry);
+      }
+      if (parsed.wishlist) {
+        state.wishlist = parsed.wishlist.map(normalizeWishlistEntry);
+      }
+      if (parsed.decks) {
+        state.decks = parsed.decks.map((deck) => ({ ...deck, cards: Array.isArray(deck.cards) ? deck.cards : [] }));
+      }
+      if (parsed.settings) {
+        state.settings = {
+          ...DEFAULT_SETTINGS,
+          ...parsed.settings,
+          exchangeRates: {
+            ...DEFAULT_SETTINGS.exchangeRates,
+            ...(parsed.settings.exchangeRates ?? {})
+          }
+        };
+      }
+      saveCollection();
+      saveWishlist();
+      saveDecks();
+      saveSettings();
+      renderAll();
+      setFeedback(dom.exportFeedback, 'Backup importiert.', 'success');
+    } catch (error) {
+      console.error('Import fehlgeschlagen', error);
+      setFeedback(dom.exportFeedback, 'Backup konnte nicht importiert werden.', 'error');
+    }
+  };
+  reader.readAsText(file);
+}
+
+function downloadCsv(rows, filename) {
+  const csv = rows.map((row) => row.map((value) => `"${String(value ?? '').replace(/"/g, '""')}"`).join(';')).join('\n');
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+  downloadBlob(blob, filename);
+}
+
+function downloadBlob(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+function startScanner() {
+  if (!navigator.mediaDevices?.getUserMedia) {
+    setFeedback(dom.scannerFeedback, 'Kamera wird nicht unterstützt. Verwende die Suche.', 'error');
+    return;
+  }
+  navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' }, audio: false })
+    .then((stream) => {
+      state.scanner.stream = stream;
+      state.scanner.isActive = true;
+      dom.scannerVideo.srcObject = stream;
+      dom.captureCardButton.disabled = false;
+      dom.stopScannerButton.disabled = false;
+      dom.startScannerButton.disabled = true;
+      setFeedback(dom.scannerFeedback, 'Kamera aktiv. Positioniere die Karte im Rahmen.');
+    })
+    .catch((error) => {
+      console.error('Scanner konnte nicht gestartet werden', error);
+      setFeedback(dom.scannerFeedback, `Kamera konnte nicht gestartet werden: ${getErrorMessage(error)}`, 'error');
+    });
 }
 
 function stopScanner() {
-  if (scannerState.stream) {
-    scannerState.stream.getTracks().forEach((track) => track.stop());
+  if (state.scanner.stream) {
+    state.scanner.stream.getTracks().forEach((track) => track.stop());
   }
-  scannerState.stream = null;
-  scannerState.isActive = false;
+  state.scanner.stream = null;
+  state.scanner.isActive = false;
   dom.scannerVideo.srcObject = null;
   dom.captureCardButton.disabled = true;
   dom.stopScannerButton.disabled = true;
@@ -600,23 +2826,20 @@ function stopScanner() {
   setFeedback(dom.scannerFeedback, 'Kamera gestoppt.');
 }
 
-async function captureCard() {
-  if (!scannerState.isActive || !scannerState.stream) {
+function captureCard() {
+  if (!state.scanner.isActive || !state.scanner.stream) {
     setFeedback(dom.scannerFeedback, 'Starte zuerst die Kamera.', 'error');
     return;
   }
-
   if (!window.Tesseract) {
     setFeedback(dom.scannerFeedback, 'Tesseract.js konnte nicht geladen werden.', 'error');
     return;
   }
-
   const video = dom.scannerVideo;
   if (!video.videoWidth || !video.videoHeight) {
-    setFeedback(dom.scannerFeedback, 'Video wird noch geladen. Bitte versuche es erneut.', 'error');
+    setFeedback(dom.scannerFeedback, 'Video wird noch geladen. Bitte erneut versuchen.', 'error');
     return;
   }
-
   const canvas = dom.scannerCanvas;
   canvas.width = video.videoWidth;
   canvas.height = video.videoHeight;
@@ -626,101 +2849,105 @@ async function captureCard() {
   dom.captureCardButton.disabled = true;
   setFeedback(dom.scannerFeedback, 'Analysiere Karte …');
 
-  try {
-    const result = await window.Tesseract.recognize(canvas, 'eng', {
-      logger: (message) => {
-        if (message.status === 'recognizing text') {
-          const progress = Math.round((message.progress || 0) * 100);
-          setFeedback(dom.scannerFeedback, `Erkenne Text … ${progress}%`);
-        }
+  window.Tesseract.recognize(canvas, 'eng', {
+    logger: (message) => {
+      if (message.status === 'recognizing text') {
+        const progress = Math.round((message.progress || 0) * 100);
+        setFeedback(dom.scannerFeedback, `Erkenne Text … ${progress}%`);
       }
-    });
-
+    }
+  }).then((result) => {
     const recognizedText = result?.data?.text?.trim();
     if (!recognizedText) {
-      setFeedback(dom.scannerFeedback, 'Keine Schrift erkannt. Bitte versuche es noch einmal.', 'error');
+      setFeedback(dom.scannerFeedback, 'Keine Schrift erkannt. Bitte erneut versuchen.', 'error');
       dom.captureCardButton.disabled = false;
       return;
     }
-
     setFeedback(dom.scannerFeedback, 'Text erkannt. Suche nach passenden Karten …');
-    const cards = await findCardsByOcr(recognizedText);
-    if (cards.length) {
-      renderCardList(cards.slice(0, MAX_SCAN_RESULTS), dom.scannerResults, {
-        feedbackElement: dom.scannerFeedback
-      });
-      setFeedback(dom.scannerFeedback, `${cards.length} mögliche Karten gefunden.`, 'success');
-    } else {
+    findCardsByOcr(recognizedText).then((cards) => {
       dom.scannerResults.innerHTML = '';
-      setFeedback(dom.scannerFeedback, 'Keine passenden Karten gefunden.', 'error');
-    }
-  } catch (error) {
+      if (cards.length) {
+        cards.forEach((card) => cardCache.set(card.id, card));
+        renderCardList(cards.slice(0, MAX_SCAN_RESULTS), dom.scannerResults, dom.scannerFeedback);
+        setFeedback(dom.scannerFeedback, `${cards.length} mögliche Karten gefunden.`, 'success');
+      } else {
+        setFeedback(dom.scannerFeedback, 'Keine passenden Karten gefunden.', 'error');
+      }
+    });
+  }).catch((error) => {
     console.error('Scan fehlgeschlagen', error);
     setFeedback(dom.scannerFeedback, `Analyse fehlgeschlagen: ${getErrorMessage(error)}`, 'error');
-  } finally {
+  }).finally(() => {
     dom.captureCardButton.disabled = false;
+  });
+}
+
+function renderCardList(cards, container, feedbackElement) {
+  container.innerHTML = '';
+  if (!cards.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.textContent = 'Keine Karten gefunden.';
+    container.append(empty);
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  cards.forEach((card) => {
+    fragment.append(createCardElement(card));
+  });
+  container.append(fragment);
+  if (feedbackElement) {
+    setFeedback(feedbackElement, `${cards.length} Karten gefunden.`, 'success');
   }
 }
 
-async function findCardsByOcr(text) {
+function findCardsByOcr(text) {
   const sanitized = text
-    .replace(/[|*_=\[\]{}<>]/g, ' ')
+    .replace(/[|*_=[\]{}<>]/g, ' ')
     .replace(/[^\w\s/.-]/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
-
   if (!sanitized) {
-    return [];
+    return Promise.resolve([]);
   }
-
   const tokens = sanitized.split(' ').filter((token) => token.length > 2);
   const phrases = buildCandidatePhrases(tokens);
-  const uniqueResults = new Map();
+  const results = new Map();
 
-  for (const phrase of phrases) {
-    if (uniqueResults.size >= MAX_SCAN_RESULTS) {
-      break;
-    }
-
-    try {
-      const params = new URLSearchParams({
-        q: `name:\"${escapeQueryValue(phrase)}\"`,
-        pageSize: '6'
-      });
-      const response = await apiFetch('/cards', params);
-      const cards = response?.data ?? [];
-      cards.forEach((card) => {
-        if (!uniqueResults.has(card.id)) {
-          uniqueResults.set(card.id, card);
+  const tasks = phrases.map((phrase) => () => {
+    const params = new URLSearchParams({
+      q: `name:\"${escapeQueryValue(phrase)}\"`,
+      pageSize: '6'
+    });
+    return apiFetch('/cards', params).then((response) => {
+      (response?.data ?? []).forEach((card) => {
+        if (!results.has(card.id)) {
+          results.set(card.id, card);
         }
       });
-    } catch (error) {
-      console.warn('Fehler bei OCR-Suche', phrase, error);
-    }
-  }
+    }).catch(() => {});
+  });
 
-  if (!uniqueResults.size) {
-    const numberMatch = sanitized.match(/\b(\d{1,3})\s*\/\s*\d{1,3}\b/);
-    if (numberMatch) {
-      const number = numberMatch[1];
-      try {
+  return runSequential(tasks).then(() => {
+    if (!results.size) {
+      const numberMatch = sanitized.match(/\b(\d{1,3})\s*\/\s*\d{1,3}\b/);
+      if (numberMatch) {
         const params = new URLSearchParams({
-          q: `number:${number}`,
+          q: `number:${numberMatch[1]}`,
           pageSize: '10'
         });
-        const response = await apiFetch('/cards', params);
-        (response?.data ?? []).forEach((card) => {
-          if (!uniqueResults.has(card.id)) {
-            uniqueResults.set(card.id, card);
-          }
+        return apiFetch('/cards', params).then((response) => {
+          (response?.data ?? []).forEach((card) => {
+            if (!results.has(card.id)) {
+              results.set(card.id, card);
+            }
+          });
+          return Array.from(results.values());
         });
-      } catch (error) {
-        console.warn('Fehler bei Nummernsuche', error);
       }
     }
-  }
-
-  return Array.from(uniqueResults.values());
+    return Array.from(results.values());
+  });
 }
 
 function buildCandidatePhrases(tokens) {
@@ -733,11 +2960,10 @@ function buildCandidatePhrases(tokens) {
       }
     }
   }
-
   return Array.from(phrases).sort((a, b) => b.length - a.length).slice(0, 15);
 }
 
-async function apiFetch(endpoint, params) {
+function apiFetch(endpoint, params) {
   const url = new URL(`${API_BASE_URL}${endpoint}`);
   if (params instanceof URLSearchParams) {
     params.forEach((value, key) => {
@@ -752,41 +2978,20 @@ async function apiFetch(endpoint, params) {
       }
     });
   }
-
-  const headers = {
-    Accept: 'application/json'
-  };
+  const headers = { Accept: 'application/json' };
   if (state.apiKey) {
     headers['X-Api-Key'] = state.apiKey;
   }
-
-  const response = await fetch(url.toString(), { headers });
-  if (!response.ok) {
-    let errorMessage = `${response.status} ${response.statusText}`;
-    if (response.status === 403) {
-      errorMessage = 'Zugriff verweigert. Bitte trage deinen API-Schlüssel ein.';
+  return fetch(url.toString(), { headers }).then((response) => {
+    if (!response.ok) {
+      let errorMessage = `${response.status} ${response.statusText}`;
+      if (response.status === 403) {
+        errorMessage = 'Zugriff verweigert. Bitte API-Schlüssel prüfen.';
+      }
+      throw new Error(errorMessage);
     }
-    throw new Error(errorMessage);
-  }
-
-  return response.json();
-}
-
-function escapeQueryValue(value) {
-  return value.replace(/"/g, '\\"');
-}
-
-function formatDate(dateString) {
-  if (!dateString) {
-    return '';
-  }
-
-  const date = new Date(dateString);
-  if (Number.isNaN(date.getTime())) {
-    return '';
-  }
-
-  return new Intl.DateTimeFormat('de-DE', { year: 'numeric', month: 'short' }).format(date);
+    return response.json();
+  });
 }
 
 function getErrorMessage(error) {
@@ -794,15 +2999,4 @@ function getErrorMessage(error) {
     return error.message;
   }
   return typeof error === 'string' ? error : 'Unbekannter Fehler';
-}
-
-function setFeedback(element, message, type) {
-  if (!element) {
-    return;
-  }
-  element.textContent = message || '';
-  element.classList.remove('error', 'success');
-  if (type) {
-    element.classList.add(type);
-  }
 }

--- a/style.css
+++ b/style.css
@@ -1,0 +1,486 @@
+:root {
+  --bg-gradient: radial-gradient(circle at top, #1b1c3a, #0b0b1d 70%);
+  --panel-bg: rgba(18, 20, 44, 0.8);
+  --card-bg: rgba(12, 13, 30, 0.9);
+  --accent: #ffcc01;
+  --accent-strong: #ff9800;
+  --accent-soft: rgba(255, 204, 1, 0.12);
+  --text-primary: #f7f8fc;
+  --text-secondary: #b0b3d6;
+  --border: rgba(255, 255, 255, 0.08);
+  --error: #f66d6d;
+  --success: #6dd47e;
+  --shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+  --radius-large: 24px;
+  --radius-medium: 18px;
+  --radius-small: 12px;
+  --transition: all 0.25s ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--bg-gradient);
+  color: var(--text-primary);
+  min-height: 100vh;
+  line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  text-decoration: underline;
+}
+
+main {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  padding: 24px 24px 80px;
+  flex: 1;
+}
+
+.app-header {
+  width: min(1200px, 100%);
+  margin: 32px auto 0;
+  padding: 32px 24px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  background: linear-gradient(135deg, rgba(32, 35, 72, 0.75), rgba(11, 12, 32, 0.9));
+  border: 1px solid var(--border);
+  border-radius: var(--radius-large);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(12px);
+}
+
+.header-content h1 {
+  margin: 0 0 12px;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  font-weight: 700;
+}
+
+.header-content p {
+  margin: 0;
+  max-width: 520px;
+  color: var(--text-secondary);
+}
+
+.api-key {
+  background: rgba(255, 255, 255, 0.04);
+  padding: 16px;
+  border-radius: var(--radius-medium);
+  border: 1px solid var(--border);
+  width: min(360px, 100%);
+}
+
+.api-key label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 500;
+}
+
+.api-key small {
+  display: block;
+  margin-top: 12px;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.api-key-controls {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.api-key input {
+  flex: 1;
+  padding: 10px 12px;
+  border-radius: var(--radius-small);
+  border: 1px solid var(--border);
+  background: rgba(9, 11, 26, 0.9);
+  color: var(--text-primary);
+}
+
+.panel {
+  margin-top: 32px;
+  padding: 28px;
+  background: var(--panel-bg);
+  border-radius: var(--radius-large);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(10px);
+}
+
+.panel-header h2 {
+  margin: 0 0 8px;
+  font-weight: 600;
+}
+
+.panel-header p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.search-form {
+  margin-top: 24px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px 20px;
+  align-items: end;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+label {
+  font-weight: 500;
+}
+
+input[type="search"],
+select {
+  padding: 10px 12px;
+  border-radius: var(--radius-small);
+  border: 1px solid var(--border);
+  background: rgba(9, 11, 26, 0.9);
+  color: var(--text-primary);
+  transition: var(--transition);
+}
+
+input[type="search"]:focus,
+select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.primary-button,
+.secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: var(--radius-small);
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.primary-button {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #201d2f;
+}
+
+.primary-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.primary-button:hover:not(:disabled),
+.primary-button:focus-visible:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 30px rgba(255, 204, 1, 0.35);
+}
+
+.secondary {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+  border: 1px solid transparent;
+}
+
+.secondary:hover,
+.secondary:focus-visible {
+  border-color: rgba(255, 255, 255, 0.22);
+  transform: translateY(-1px);
+}
+
+.feedback {
+  margin-top: 18px;
+  padding: 12px 14px;
+  border-radius: var(--radius-small);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-secondary);
+  border: 1px dashed transparent;
+  min-height: 20px;
+}
+
+.feedback.error {
+  color: var(--error);
+  border-color: rgba(246, 109, 109, 0.4);
+  background: rgba(246, 109, 109, 0.1);
+}
+
+.feedback.success {
+  color: var(--success);
+  border-color: rgba(109, 212, 126, 0.4);
+  background: rgba(109, 212, 126, 0.1);
+}
+
+.card-grid {
+  margin-top: 24px;
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: var(--radius-medium);
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+  transition: transform 0.3s ease, border 0.3s ease;
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(135deg, rgba(255, 204, 1, 0.3), rgba(255, 255, 255, 0));
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(255, 204, 1, 0.35);
+}
+
+.card-image-wrapper {
+  background: rgba(255, 255, 255, 0.04);
+  padding: 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 260px;
+}
+
+.card-image {
+  width: 100%;
+  height: auto;
+  max-width: 230px;
+  border-radius: 12px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+}
+
+.card-body {
+  padding: 18px 20px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1;
+}
+
+.card-title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.card-subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.card-meta {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.card-actions {
+  padding: 18px 20px 20px;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.card-actions .secondary {
+  flex: 1;
+  text-align: center;
+}
+
+.card-actions .remove-button {
+  flex: none;
+}
+
+.quantity-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.quantity-button {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-primary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.quantity-button:hover,
+.quantity-button:focus-visible {
+  border-color: rgba(255, 204, 1, 0.6);
+  transform: translateY(-1px);
+}
+
+.quantity-value {
+  min-width: 28px;
+  text-align: center;
+  font-weight: 600;
+}
+
+.empty-state {
+  margin-top: 16px;
+  padding: 18px;
+  border-radius: var(--radius-small);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-secondary);
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+}
+
+.set-grid {
+  margin-top: 24px;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+}
+
+.set-card {
+  background: var(--card-bg);
+  border-radius: var(--radius-medium);
+  border: 1px solid var(--border);
+  padding: 18px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 16px;
+  align-items: center;
+  transition: var(--transition);
+}
+
+.set-card:hover {
+  border-color: rgba(255, 204, 1, 0.35);
+  transform: translateY(-4px);
+}
+
+.set-card img {
+  width: 60px;
+  height: 60px;
+  object-fit: contain;
+}
+
+.set-card h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.set-card p {
+  margin: 6px 0 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.scanner-controls {
+  margin-top: 24px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.scanner-view {
+  position: relative;
+  margin-top: 20px;
+  border-radius: var(--radius-large);
+  overflow: hidden;
+  border: 2px dashed rgba(255, 255, 255, 0.2);
+  background: rgba(0, 0, 0, 0.4);
+  min-height: 280px;
+  display: grid;
+  place-items: center;
+}
+
+#scannerVideo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.scanner-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  display: grid;
+  place-items: end center;
+  padding: 20px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.8);
+  background: linear-gradient(180deg, rgba(15, 18, 42, 0) 40%, rgba(15, 18, 42, 0.65));
+}
+
+.app-footer {
+  margin-top: auto;
+  padding: 24px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+  main {
+    padding: 16px 16px 64px;
+  }
+
+  .app-header {
+    margin: 16px auto 0;
+    padding: 24px 18px;
+  }
+
+  .card-grid {
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  }
+
+  .set-grid {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  }
+}
+
+@media (max-width: 560px) {
+  .api-key-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .card-actions {
+    flex-direction: column;
+  }
+
+  .primary-button,
+  .secondary {
+    width: 100%;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,20 +1,33 @@
 :root {
-  --bg-gradient: radial-gradient(circle at top, #1b1c3a, #0b0b1d 70%);
-  --panel-bg: rgba(18, 20, 44, 0.8);
-  --card-bg: rgba(12, 13, 30, 0.9);
-  --accent: #ffcc01;
-  --accent-strong: #ff9800;
-  --accent-soft: rgba(255, 204, 1, 0.12);
-  --text-primary: #f7f8fc;
-  --text-secondary: #b0b3d6;
-  --border: rgba(255, 255, 255, 0.08);
-  --error: #f66d6d;
-  --success: #6dd47e;
-  --shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
-  --radius-large: 24px;
-  --radius-medium: 18px;
-  --radius-small: 12px;
-  --transition: all 0.25s ease;
+  color-scheme: dark;
+  --font-family: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --color-bg: #0f172a;
+  --color-surface: rgba(15, 23, 42, 0.75);
+  --color-surface-alt: rgba(30, 41, 59, 0.85);
+  --color-border: rgba(148, 163, 184, 0.25);
+  --color-text: #e2e8f0;
+  --color-text-muted: #94a3b8;
+  --color-primary: #38bdf8;
+  --color-primary-contrast: #0f172a;
+  --color-success: #22c55e;
+  --color-danger: #f87171;
+  --shadow-soft: 0 18px 45px rgba(15, 23, 42, 0.55);
+  --backdrop-blur: blur(22px);
+  --transition-speed: 0.2s;
+  font-size: 16px;
+}
+
+[data-theme='light'] {
+  color-scheme: light;
+  --color-bg: #f1f5f9;
+  --color-surface: rgba(255, 255, 255, 0.82);
+  --color-surface-alt: rgba(241, 245, 249, 0.9);
+  --color-border: rgba(15, 23, 42, 0.12);
+  --color-text: #0f172a;
+  --color-text-muted: #475569;
+  --color-primary: #2563eb;
+  --color-primary-contrast: #f8fafc;
+  --shadow-soft: 0 18px 45px rgba(15, 23, 42, 0.12);
 }
 
 * {
@@ -23,273 +36,325 @@
 
 body {
   margin: 0;
-  font-family: 'Roboto', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: var(--bg-gradient);
-  color: var(--text-primary);
   min-height: 100vh;
-  line-height: 1.6;
   display: flex;
   flex-direction: column;
-}
-
-a {
-  color: var(--accent);
-  text-decoration: none;
-}
-
-a:hover,
-a:focus-visible {
-  text-decoration: underline;
+  font-family: var(--font-family);
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.12), transparent 55%) no-repeat,
+    radial-gradient(circle at bottom, rgba(14, 165, 233, 0.08), transparent 50%) no-repeat,
+    var(--color-bg);
+  color: var(--color-text);
 }
 
 main {
-  width: min(1200px, 100%);
+  width: min(1200px, 94vw);
   margin: 0 auto;
-  padding: 24px 24px 80px;
   flex: 1;
+  padding: 2rem 0 4rem;
 }
 
 .app-header {
-  width: min(1200px, 100%);
-  margin: 32px auto 0;
-  padding: 32px 24px;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: var(--backdrop-blur);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(17, 24, 39, 0.75));
+  border-bottom: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  padding: 1.5rem clamp(1.5rem, 3vw, 3rem) 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.branding h1 {
+  margin: 0 0 0.25rem;
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  letter-spacing: 0.03em;
+}
+
+.branding p {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.header-actions {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: center;
-  gap: 24px;
-  background: linear-gradient(135deg, rgba(32, 35, 72, 0.75), rgba(11, 12, 32, 0.9));
-  border: 1px solid var(--border);
-  border-radius: var(--radius-large);
-  box-shadow: var(--shadow);
-  backdrop-filter: blur(12px);
-}
-
-.header-content h1 {
-  margin: 0 0 12px;
-  font-size: clamp(2rem, 4vw, 2.8rem);
-  font-weight: 700;
-}
-
-.header-content p {
-  margin: 0;
-  max-width: 520px;
-  color: var(--text-secondary);
+  gap: 1rem;
 }
 
 .api-key {
-  background: rgba(255, 255, 255, 0.04);
-  padding: 16px;
-  border-radius: var(--radius-medium);
-  border: 1px solid var(--border);
-  width: min(360px, 100%);
+  flex: 1;
+  min-width: 260px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  padding: 1rem;
+  box-shadow: var(--shadow-soft);
 }
 
 .api-key label {
+  font-weight: 600;
   display: block;
-  margin-bottom: 8px;
-  font-weight: 500;
-}
-
-.api-key small {
-  display: block;
-  margin-top: 12px;
-  color: var(--text-secondary);
-  font-size: 0.85rem;
+  margin-bottom: 0.5rem;
 }
 
 .api-key-controls {
   display: flex;
-  gap: 12px;
-  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .api-key input {
   flex: 1;
-  padding: 10px 12px;
-  border-radius: var(--radius-small);
-  border: 1px solid var(--border);
-  background: rgba(9, 11, 26, 0.9);
-  color: var(--text-primary);
+  min-width: 200px;
+}
+
+.main-nav {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.nav-button {
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.6rem 1.3rem;
+  background: transparent;
+  color: var(--color-text);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-speed) ease;
+}
+
+.nav-button:is(:hover, :focus-visible) {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.nav-button.is-active {
+  background: var(--color-primary);
+  color: var(--color-primary-contrast);
+  box-shadow: 0 12px 24px rgba(56, 189, 248, 0.28);
+}
+
+.view {
+  display: none;
+  margin-top: 2rem;
+  gap: 2rem;
+}
+
+.view.is-active {
+  display: grid;
 }
 
 .panel {
-  margin-top: 32px;
-  padding: 28px;
-  background: var(--panel-bg);
-  border-radius: var(--radius-large);
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow);
-  backdrop-filter: blur(10px);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 24px;
+  padding: clamp(1.5rem, 2.5vw, 2.25rem);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
-.panel-header h2 {
-  margin: 0 0 8px;
-  font-weight: 600;
+.panel-header h2,
+.panel-header h3 {
+  margin: 0 0 0.35rem;
 }
 
 .panel-header p {
   margin: 0;
-  color: var(--text-secondary);
+  color: var(--color-text-muted);
 }
 
 .search-form {
-  margin-top: 24px;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 16px 20px;
-  align-items: end;
-}
-
-.form-group {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 1.25rem;
 }
 
-label {
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.form-row label,
+.form-row span {
   font-weight: 500;
 }
 
-input[type="search"],
-select {
-  padding: 10px 12px;
-  border-radius: var(--radius-small);
-  border: 1px solid var(--border);
-  background: rgba(9, 11, 26, 0.9);
-  color: var(--text-primary);
-  transition: var(--transition);
+.filter-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
-input[type="search"]:focus,
-select:focus {
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+input[type='text'],
+input[type='search'],
+input[type='number'],
+input[type='date'],
+select,
+textarea {
+  font: inherit;
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 0.65rem 0.75rem;
+  transition: border-color var(--transition-speed) ease;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 5rem;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
   outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-soft);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.22);
 }
 
 .primary-button,
-.secondary {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 10px 18px;
-  border-radius: var(--radius-small);
+.secondary,
+.secondary.danger {
   border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
   font-weight: 600;
   cursor: pointer;
-  transition: var(--transition);
+  transition: transform var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
 }
 
 .primary-button {
-  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  color: #201d2f;
+  background: linear-gradient(135deg, var(--color-primary), rgba(56, 189, 248, 0.75));
+  color: var(--color-primary-contrast);
+  box-shadow: 0 10px 25px rgba(56, 189, 248, 0.35);
 }
 
-.primary-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.primary-button:hover:not(:disabled),
-.primary-button:focus-visible:not(:disabled) {
+.primary-button:is(:hover, :focus-visible) {
   transform: translateY(-1px);
-  box-shadow: 0 10px 30px rgba(255, 204, 1, 0.35);
+  box-shadow: 0 16px 32px rgba(56, 189, 248, 0.4);
 }
 
 .secondary {
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--text-primary);
-  border: 1px solid transparent;
+  background: transparent;
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
 }
 
-.secondary:hover,
-.secondary:focus-visible {
-  border-color: rgba(255, 255, 255, 0.22);
-  transform: translateY(-1px);
+.secondary:is(:hover, :focus-visible) {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.secondary.danger {
+  border-color: rgba(248, 113, 113, 0.45);
+  color: var(--color-danger);
+}
+
+.secondary.danger:is(:hover, :focus-visible) {
+  background: rgba(248, 113, 113, 0.15);
+  color: #fff;
 }
 
 .feedback {
-  margin-top: 18px;
-  padding: 12px 14px;
-  border-radius: var(--radius-small);
-  background: rgba(255, 255, 255, 0.05);
-  color: var(--text-secondary);
-  border: 1px dashed transparent;
-  min-height: 20px;
-}
-
-.feedback.error {
-  color: var(--error);
-  border-color: rgba(246, 109, 109, 0.4);
-  background: rgba(246, 109, 109, 0.1);
+  min-height: 1.4rem;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
 }
 
 .feedback.success {
-  color: var(--success);
-  border-color: rgba(109, 212, 126, 0.4);
-  background: rgba(109, 212, 126, 0.1);
+  color: var(--color-success);
+}
+
+.feedback.error {
+  color: var(--color-danger);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 3rem 1rem;
+  border: 1px dashed var(--color-border);
+  border-radius: 16px;
+  color: var(--color-text-muted);
 }
 
 .card-grid {
-  margin-top: 24px;
   display: grid;
-  gap: 20px;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
 }
 
 .card {
-  background: var(--card-bg);
-  border-radius: var(--radius-medium);
-  border: 1px solid var(--border);
+  position: relative;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  position: relative;
-  transition: transform 0.3s ease, border 0.3s ease;
+  gap: 1rem;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: 20px;
+  padding: 1.25rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.35);
+  transition: transform var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
 }
 
-.card::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  padding: 1px;
-  background: linear-gradient(135deg, rgba(255, 204, 1, 0.3), rgba(255, 255, 255, 0));
-  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-          mask-composite: exclude;
-}
-
-.card:hover {
-  transform: translateY(-6px);
-  border-color: rgba(255, 204, 1, 0.35);
+.card:is(:hover, :focus-within) {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 40px rgba(56, 189, 248, 0.2);
 }
 
 .card-image-wrapper {
-  background: rgba(255, 255, 255, 0.04);
-  padding: 16px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 260px;
+  position: relative;
+  aspect-ratio: 3 / 4;
+  border-radius: 14px;
+  overflow: hidden;
+  background: rgba(148, 163, 184, 0.15);
 }
 
 .card-image {
   width: 100%;
-  height: auto;
-  max-width: 230px;
-  border-radius: 12px;
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+  height: 100%;
+  object-fit: cover;
+}
+
+.card-badges {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.badge {
+  background: rgba(15, 23, 42, 0.75);
+  color: #f8fafc;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .card-body {
-  padding: 18px 20px 0;
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  flex: 1;
+  gap: 0.5rem;
 }
 
 .card-title {
@@ -299,132 +364,91 @@ select:focus {
 
 .card-subtitle {
   margin: 0;
-  color: var(--text-secondary);
+  color: var(--color-text-muted);
   font-size: 0.95rem;
 }
 
 .card-meta {
+  list-style: none;
   margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.card-meta li::before {
+  content: '•';
+  margin-right: 0.35rem;
+}
+
+.card-meta li:first-child::before {
+  content: '';
+  margin: 0;
+}
+
+.card-price {
+  margin: 0;
+  font-weight: 600;
+}
+
+.card-notes,
+.card-target {
+  margin: 0;
+  color: var(--color-text-muted);
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.7);
 }
 
 .card-actions {
-  padding: 18px 20px 20px;
   display: flex;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.card-actions .secondary {
-  flex: 1;
-  text-align: center;
-}
-
-.card-actions .remove-button {
-  flex: none;
-}
-
-.quantity-controls {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.quantity-button {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(255, 255, 255, 0.1);
-  color: var(--text-primary);
-  font-weight: 600;
-  cursor: pointer;
-  transition: var(--transition);
-}
-
-.quantity-button:hover,
-.quantity-button:focus-visible {
-  border-color: rgba(255, 204, 1, 0.6);
-  transform: translateY(-1px);
-}
-
-.quantity-value {
-  min-width: 28px;
-  text-align: center;
-  font-weight: 600;
-}
-
-.empty-state {
-  margin-top: 16px;
-  padding: 18px;
-  border-radius: var(--radius-small);
-  background: rgba(255, 255, 255, 0.05);
-  color: var(--text-secondary);
-  border: 1px dashed rgba(255, 255, 255, 0.12);
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .set-grid {
-  margin-top: 24px;
   display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .set-card {
-  background: var(--card-bg);
-  border-radius: var(--radius-medium);
-  border: 1px solid var(--border);
-  padding: 18px;
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 16px;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 16px;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
   align-items: center;
-  transition: var(--transition);
-}
-
-.set-card:hover {
-  border-color: rgba(255, 204, 1, 0.35);
-  transform: translateY(-4px);
 }
 
 .set-card img {
-  width: 60px;
-  height: 60px;
+  width: 48px;
+  height: 48px;
   object-fit: contain;
-}
-
-.set-card h3 {
-  margin: 0;
-  font-size: 1rem;
-}
-
-.set-card p {
-  margin: 6px 0 0;
-  color: var(--text-secondary);
-  font-size: 0.9rem;
+  filter: drop-shadow(0 8px 12px rgba(15, 23, 42, 0.3));
 }
 
 .scanner-controls {
-  margin-top: 24px;
   display: flex;
+  gap: 0.75rem;
   flex-wrap: wrap;
-  gap: 12px;
 }
 
 .scanner-view {
   position: relative;
-  margin-top: 20px;
-  border-radius: var(--radius-large);
+  width: 100%;
+  max-width: 640px;
+  margin: 0 auto;
+  aspect-ratio: 3 / 4;
+  border-radius: 24px;
   overflow: hidden;
-  border: 2px dashed rgba(255, 255, 255, 0.2);
-  background: rgba(0, 0, 0, 0.4);
-  min-height: 280px;
-  display: grid;
-  place-items: center;
+  border: 2px dashed rgba(56, 189, 248, 0.35);
 }
 
-#scannerVideo {
+.scanner-view video {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -433,54 +457,324 @@ select:focus {
 .scanner-overlay {
   position: absolute;
   inset: 0;
-  pointer-events: none;
   display: grid;
-  place-items: end center;
-  padding: 20px;
-  font-weight: 500;
-  color: rgba(255, 255, 255, 0.8);
-  background: linear-gradient(180deg, rgba(15, 18, 42, 0) 40%, rgba(15, 18, 42, 0.65));
+  place-items: center;
+  text-align: center;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.2), transparent 50%, rgba(15, 23, 42, 0.5));
+  color: var(--color-text);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.summary-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.summary-card {
+  background: var(--color-surface-alt);
+  border-radius: 16px;
+  padding: 1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  border: 1px solid var(--color-border);
+}
+
+.summary-card strong {
+  font-size: 1.4rem;
+}
+
+.progress-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.progress-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.progress-bar {
+  position: relative;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  overflow: hidden;
+}
+
+.progress-bar span {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--color-primary), rgba(56, 189, 248, 0.3));
+}
+
+.alerts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.alert {
+  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  border-radius: 14px;
+  padding: 1rem;
+}
+
+.alert strong {
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.deck-panel .panel-header {
+  margin-bottom: 0;
+}
+
+.deck-layout {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(220px, 280px) 1fr;
+}
+
+.deck-list {
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.deck-list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.deck-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.deck-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(148, 163, 184, 0.08);
+  border: 1px solid transparent;
+}
+
+.deck-item.is-active {
+  border-color: var(--color-primary);
+  background: rgba(56, 189, 248, 0.15);
+}
+
+.deck-select-button {
+  flex: 1;
+  text-align: left;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.deck-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.deck-detail {
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.deck-detail table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.deck-detail th,
+.deck-detail td {
+  padding: 0.35rem 0.25rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.deck-detail tfoot td {
+  font-weight: 600;
+}
+
+.deck-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.export-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.file-import {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  border: 1px dashed var(--color-border);
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  color: var(--color-text-muted);
+  transition: border-color var(--transition-speed) ease;
+}
+
+.file-import:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.file-import input {
+  display: none;
+}
+
+.settings-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.form-row-wide {
+  grid-column: 1 / -1;
+}
+
+.settings-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
 .app-footer {
-  margin-top: auto;
-  padding: 24px;
+  padding: 2rem clamp(1.5rem, 3vw, 3rem);
+  color: var(--color-text-muted);
   text-align: center;
-  color: var(--text-secondary);
-  font-size: 0.9rem;
+  border-top: 1px solid var(--color-border);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.85), rgba(15, 23, 42, 0.6));
 }
 
-@media (max-width: 768px) {
-  main {
-    padding: 16px 16px 64px;
-  }
+.app-footer a {
+  color: var(--color-primary);
+}
 
-  .app-header {
-    margin: 16px auto 0;
-    padding: 24px 18px;
+.dialog-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+card-preview,
+.card-preview {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 1rem;
+  align-items: center;
+}
+
+.card-preview img {
+  width: 100px;
+  height: auto;
+  border-radius: 12px;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.4);
+}
+
+form-grid,
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.dialog-prices {
+  margin: 0;
+  font-weight: 600;
+}
+
+::backdrop {
+  background: rgba(15, 23, 42, 0.5);
+  backdrop-filter: blur(6px);
+}
+
+#deckPickerDialog select,
+#cardEditorDialog select {
+  min-width: 160px;
+}
+
+#deckPickerDialog .dialog-body,
+#deckEditorDialog .dialog-body {
+  display: grid;
+  gap: 0.75rem;
+}
+
+#deckDetail .empty-state {
+  margin: 2rem 0;
+}
+
+@media (max-width: 960px) {
+  .deck-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  main {
+    width: 100%;
+    padding: 1.5rem 1.25rem 3rem;
   }
 
   .card-grid {
-    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
 
-  .set-grid {
-    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  }
-}
-
-@media (max-width: 560px) {
-  .api-key-controls {
-    flex-direction: column;
-    align-items: stretch;
+  .card-preview {
+    grid-template-columns: 1fr;
+    text-align: center;
   }
 
-  .card-actions {
-    flex-direction: column;
-  }
-
-  .primary-button,
-  .secondary {
-    width: 100%;
+  .card-preview img {
+    justify-self: center;
   }
 }


### PR DESCRIPTION
## Summary
- add a responsive landing page with search, collection, and scanner sections for Pokémon TCG cards
- style the interface with a dark glassmorphism theme and card/grid layouts
- implement API-powered search, local collection management, and OCR-based camera scanning with Tesseract.js

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c9c408f1988323bca5c3b513e5e1f8